### PR TITLE
Fix missing mob drop mapping for Spinetinglers in Fusion Billy's Lair

### DIFF
--- a/drops.json
+++ b/drops.json
@@ -5991,6 +5991,10 @@
             "MobID": 1340,
             "MobDropID": 30
         },
+        "395a": {
+            "MobID": 1342,
+            "MobDropID": 34
+        },
         "396": {
             "MobID": 1435,
             "MobDropID": 38


### PR DESCRIPTION
#13 put the correct Spinetingler mobs in Fusion Billy's Lair that match the mission's mob ID (1342), but for some reason the drop table didn't have it hooked up.
Verified the mob drop ID through the Spingetingler's XDT entry and made sure the C.R.A.T.E.S. drop level 9 items.