### PR TITLE
FM - Taro Overhaul and Mob Drop Reserved Slots

### DIFF
--- a/drops.json
+++ b/drops.json
@@ -1040,8 +1040,8 @@
             "MiscDropTypeID": 0,
             "PotionAmount": 0,
             "BoostAmount": 0,
-            "TaroAmount": 12,
-            "FMAmount": 9
+            "TaroAmount": 0,
+            "FMAmount": 0
         },
         "1": {
             "MiscDropTypeID": 1,
@@ -1054,5706 +1054,5692 @@
             "MiscDropTypeID": 2,
             "PotionAmount": 0,
             "BoostAmount": 0,
-            "TaroAmount": 36,
-            "FMAmount": 27
+            "TaroAmount": 13,
+            "FMAmount": 10
         },
         "3": {
             "MiscDropTypeID": 3,
             "PotionAmount": 0,
             "BoostAmount": 0,
-            "TaroAmount": 31,
-            "FMAmount": 16
+            "TaroAmount": 45,
+            "FMAmount": 23
         },
         "4": {
             "MiscDropTypeID": 4,
             "PotionAmount": 0,
             "BoostAmount": 0,
-            "TaroAmount": 13,
-            "FMAmount": 10
+            "TaroAmount": 75,
+            "FMAmount": 18
         },
         "5": {
             "MiscDropTypeID": 5,
             "PotionAmount": 0,
             "BoostAmount": 0,
-            "TaroAmount": 39,
-            "FMAmount": 30
+            "TaroAmount": 31,
+            "FMAmount": 16
         },
         "6": {
             "MiscDropTypeID": 6,
             "PotionAmount": 0,
             "BoostAmount": 0,
-            "TaroAmount": 14,
-            "FMAmount": 11
+            "TaroAmount": 13,
+            "FMAmount": 10
         },
         "7": {
             "MiscDropTypeID": 7,
             "PotionAmount": 0,
             "BoostAmount": 0,
-            "TaroAmount": 32,
-            "FMAmount": 17
+            "TaroAmount": 46,
+            "FMAmount": 24
         },
         "8": {
             "MiscDropTypeID": 8,
             "PotionAmount": 0,
             "BoostAmount": 0,
-            "TaroAmount": 42,
-            "FMAmount": 33
+            "TaroAmount": 77,
+            "FMAmount": 19
         },
         "9": {
             "MiscDropTypeID": 9,
             "PotionAmount": 0,
             "BoostAmount": 0,
-            "TaroAmount": 14,
-            "FMAmount": 12
+            "TaroAmount": 32,
+            "FMAmount": 17
         },
         "10": {
             "MiscDropTypeID": 10,
             "PotionAmount": 0,
             "BoostAmount": 0,
-            "TaroAmount": 33,
-            "FMAmount": 18
+            "TaroAmount": 14,
+            "FMAmount": 11
         },
         "11": {
             "MiscDropTypeID": 11,
             "PotionAmount": 0,
             "BoostAmount": 0,
-            "TaroAmount": 42,
-            "FMAmount": 36
+            "TaroAmount": 48,
+            "FMAmount": 26
         },
         "12": {
             "MiscDropTypeID": 12,
+            "PotionAmount": 0,
+            "BoostAmount": 0,
+            "TaroAmount": 80,
+            "FMAmount": 20
+        },
+        "13": {
+            "MiscDropTypeID": 13,
+            "PotionAmount": 0,
+            "BoostAmount": 0,
+            "TaroAmount": 33,
+            "FMAmount": 18
+        },
+        "14": {
+            "MiscDropTypeID": 14,
+            "PotionAmount": 0,
+            "BoostAmount": 0,
+            "TaroAmount": 14,
+            "FMAmount": 12
+        },
+        "15": {
+            "MiscDropTypeID": 15,
+            "PotionAmount": 0,
+            "BoostAmount": 0,
+            "TaroAmount": 49,
+            "FMAmount": 27
+        },
+        "16": {
+            "MiscDropTypeID": 16,
+            "PotionAmount": 0,
+            "BoostAmount": 0,
+            "TaroAmount": 82,
+            "FMAmount": 22
+        },
+        "17": {
+            "MiscDropTypeID": 17,
             "PotionAmount": 16,
             "BoostAmount": 16,
             "TaroAmount": 34,
             "FMAmount": 19
         },
-        "13": {
-            "MiscDropTypeID": 13,
+        "18": {
+            "MiscDropTypeID": 18,
             "PotionAmount": 16,
             "BoostAmount": 16,
             "TaroAmount": 15,
             "FMAmount": 12
         },
-        "14": {
-            "MiscDropTypeID": 14,
+        "19": {
+            "MiscDropTypeID": 19,
             "PotionAmount": 16,
             "BoostAmount": 16,
-            "TaroAmount": 45,
-            "FMAmount": 36
+            "TaroAmount": 51,
+            "FMAmount": 29
         },
-        "15": {
-            "MiscDropTypeID": 15,
+        "20": {
+            "MiscDropTypeID": 20,
+            "PotionAmount": 16,
+            "BoostAmount": 16,
+            "TaroAmount": 85,
+            "FMAmount": 23
+        },
+        "21": {
+            "MiscDropTypeID": 21,
+            "PotionAmount": 16,
+            "BoostAmount": 16,
+            "TaroAmount": 35,
+            "FMAmount": 20
+        },
+        "22": {
+            "MiscDropTypeID": 22,
             "PotionAmount": 16,
             "BoostAmount": 16,
             "TaroAmount": 15,
             "FMAmount": 13
         },
-        "16": {
-            "MiscDropTypeID": 16,
+        "23": {
+            "MiscDropTypeID": 23,
             "PotionAmount": 16,
             "BoostAmount": 16,
-            "TaroAmount": 45,
-            "FMAmount": 39
+            "TaroAmount": 52,
+            "FMAmount": 30
         },
-        "17": {
-            "MiscDropTypeID": 17,
+        "24": {
+            "MiscDropTypeID": 24,
+            "PotionAmount": 16,
+            "BoostAmount": 16,
+            "TaroAmount": 87,
+            "FMAmount": 24
+        },
+        "25": {
+            "MiscDropTypeID": 25,
             "PotionAmount": 17,
             "BoostAmount": 17,
             "TaroAmount": 36,
             "FMAmount": 21
         },
-        "18": {
-            "MiscDropTypeID": 18,
-            "PotionAmount": 17,
-            "BoostAmount": 17,
-            "TaroAmount": 108,
-            "FMAmount": 63
-        },
-        "19": {
-            "MiscDropTypeID": 19,
+        "26": {
+            "MiscDropTypeID": 26,
             "PotionAmount": 17,
             "BoostAmount": 17,
             "TaroAmount": 16,
             "FMAmount": 14
         },
-        "20": {
-            "MiscDropTypeID": 20,
+        "27": {
+            "MiscDropTypeID": 27,
             "PotionAmount": 17,
             "BoostAmount": 17,
-            "TaroAmount": 48,
-            "FMAmount": 42
+            "TaroAmount": 54,
+            "FMAmount": 32
         },
-        "21": {
-            "MiscDropTypeID": 21,
+        "28": {
+            "MiscDropTypeID": 28,
+            "PotionAmount": 17,
+            "BoostAmount": 17,
+            "TaroAmount": 90,
+            "FMAmount": 25
+        },
+        "29": {
+            "MiscDropTypeID": 29,
             "PotionAmount": 17,
             "BoostAmount": 17,
             "TaroAmount": 37,
             "FMAmount": 22
         },
-        "22": {
-            "MiscDropTypeID": 22,
+        "30": {
+            "MiscDropTypeID": 30,
+            "PotionAmount": 17,
+            "BoostAmount": 17,
+            "TaroAmount": 16,
+            "FMAmount": 14
+        },
+        "31": {
+            "MiscDropTypeID": 31,
+            "PotionAmount": 17,
+            "BoostAmount": 17,
+            "TaroAmount": 55,
+            "FMAmount": 33
+        },
+        "32": {
+            "MiscDropTypeID": 32,
+            "PotionAmount": 17,
+            "BoostAmount": 17,
+            "TaroAmount": 92,
+            "FMAmount": 26
+        },
+        "33": {
+            "MiscDropTypeID": 33,
             "PotionAmount": 18,
             "BoostAmount": 18,
             "TaroAmount": 38,
             "FMAmount": 23
         },
-        "23": {
-            "MiscDropTypeID": 23,
-            "PotionAmount": 18,
-            "BoostAmount": 18,
-            "TaroAmount": 51,
-            "FMAmount": 48
-        },
-        "24": {
-            "MiscDropTypeID": 24,
-            "PotionAmount": 18,
-            "BoostAmount": 18,
-            "TaroAmount": 39,
-            "FMAmount": 16
-        },
-        "25": {
-            "MiscDropTypeID": 25,
-            "PotionAmount": 18,
-            "BoostAmount": 18,
-            "TaroAmount": 17,
-            "FMAmount": 16
-        },
-        "26": {
-            "MiscDropTypeID": 26,
-            "PotionAmount": 18,
-            "BoostAmount": 18,
-            "TaroAmount": 117,
-            "FMAmount": 69
-        },
-        "27": {
-            "MiscDropTypeID": 27,
-            "PotionAmount": 19,
-            "BoostAmount": 19,
-            "TaroAmount": 40,
-            "FMAmount": 25
-        },
-        "28": {
-            "MiscDropTypeID": 28,
-            "PotionAmount": 19,
-            "BoostAmount": 19,
-            "TaroAmount": 120,
-            "FMAmount": 75
-        },
-        "29": {
-            "MiscDropTypeID": 29,
-            "PotionAmount": 19,
-            "BoostAmount": 19,
-            "TaroAmount": 18,
-            "FMAmount": 17
-        },
-        "30": {
-            "MiscDropTypeID": 30,
-            "PotionAmount": 19,
-            "BoostAmount": 19,
-            "TaroAmount": 54,
-            "FMAmount": 51
-        },
-        "31": {
-            "MiscDropTypeID": 31,
-            "PotionAmount": 19,
-            "BoostAmount": 19,
-            "TaroAmount": 41,
-            "FMAmount": 26
-        },
-        "32": {
-            "MiscDropTypeID": 32,
-            "PotionAmount": 20,
-            "BoostAmount": 20,
-            "TaroAmount": 19,
-            "FMAmount": 18
-        },
-        "33": {
-            "MiscDropTypeID": 33,
-            "PotionAmount": 20,
-            "BoostAmount": 20,
-            "TaroAmount": 57,
-            "FMAmount": 54
-        },
         "34": {
             "MiscDropTypeID": 34,
-            "PotionAmount": 20,
-            "BoostAmount": 20,
-            "TaroAmount": 42,
-            "FMAmount": 27
-        },
-        "35": {
-            "MiscDropTypeID": 35,
-            "PotionAmount": 20,
-            "BoostAmount": 20,
-            "TaroAmount": 43,
-            "FMAmount": 28
-        },
-        "36": {
-            "MiscDropTypeID": 36,
-            "PotionAmount": 21,
-            "BoostAmount": 21,
-            "TaroAmount": 20,
-            "FMAmount": 19
-        },
-        "37": {
-            "MiscDropTypeID": 37,
-            "PotionAmount": 21,
-            "BoostAmount": 21,
-            "TaroAmount": 60,
-            "FMAmount": 57
-        },
-        "38": {
-            "MiscDropTypeID": 38,
-            "PotionAmount": 21,
-            "BoostAmount": 21,
-            "TaroAmount": 44,
-            "FMAmount": 29
-        },
-        "39": {
-            "MiscDropTypeID": 39,
-            "PotionAmount": 21,
-            "BoostAmount": 21,
-            "TaroAmount": 46,
-            "FMAmount": 30
-        },
-        "40": {
-            "MiscDropTypeID": 40,
-            "PotionAmount": 21,
-            "BoostAmount": 21,
-            "TaroAmount": 60,
-            "FMAmount": 60
-        },
-        "41": {
-            "MiscDropTypeID": 41,
-            "PotionAmount": 22,
-            "BoostAmount": 22,
-            "TaroAmount": 48,
-            "FMAmount": 32
-        },
-        "42": {
-            "MiscDropTypeID": 42,
-            "PotionAmount": 22,
-            "BoostAmount": 22,
-            "TaroAmount": 63,
-            "FMAmount": 63
-        },
-        "43": {
-            "MiscDropTypeID": 43,
-            "PotionAmount": 23,
-            "BoostAmount": 23,
-            "TaroAmount": 21,
-            "FMAmount": 22
-        },
-        "44": {
-            "MiscDropTypeID": 44,
-            "PotionAmount": 23,
-            "BoostAmount": 23,
-            "TaroAmount": 63,
-            "FMAmount": 66
-        },
-        "45": {
-            "MiscDropTypeID": 45,
-            "PotionAmount": 24,
-            "BoostAmount": 24,
-            "TaroAmount": 52,
-            "FMAmount": 36
-        },
-        "46": {
-            "MiscDropTypeID": 46,
-            "PotionAmount": 24,
-            "BoostAmount": 24,
-            "TaroAmount": 66,
-            "FMAmount": 72
-        },
-        "47": {
-            "MiscDropTypeID": 47,
-            "PotionAmount": 25,
-            "BoostAmount": 25,
-            "TaroAmount": 54,
-            "FMAmount": 38
-        },
-        "48": {
-            "MiscDropTypeID": 48,
-            "PotionAmount": 25,
-            "BoostAmount": 25,
-            "TaroAmount": 69,
-            "FMAmount": 78
-        },
-        "49": {
-            "MiscDropTypeID": 49,
-            "PotionAmount": 26,
-            "BoostAmount": 26,
-            "TaroAmount": 56,
-            "FMAmount": 40
-        },
-        "50": {
-            "MiscDropTypeID": 50,
-            "PotionAmount": 26,
-            "BoostAmount": 26,
-            "TaroAmount": 72,
-            "FMAmount": 84
-        },
-        "51": {
-            "MiscDropTypeID": 51,
-            "PotionAmount": 27,
-            "BoostAmount": 27,
-            "TaroAmount": 58,
-            "FMAmount": 42
-        },
-        "52": {
-            "MiscDropTypeID": 52,
-            "PotionAmount": 27,
-            "BoostAmount": 27,
-            "TaroAmount": 75,
-            "FMAmount": 90
-        },
-        "53": {
-            "MiscDropTypeID": 53,
-            "PotionAmount": 28,
-            "BoostAmount": 28,
-            "TaroAmount": 60,
-            "FMAmount": 44
-        },
-        "54": {
-            "MiscDropTypeID": 54,
-            "PotionAmount": 28,
-            "BoostAmount": 28,
-            "TaroAmount": 78,
-            "FMAmount": 96
-        },
-        "55": {
-            "MiscDropTypeID": 55,
-            "PotionAmount": 29,
-            "BoostAmount": 29,
-            "TaroAmount": 62,
-            "FMAmount": 46
-        },
-        "56": {
-            "MiscDropTypeID": 56,
-            "PotionAmount": 29,
-            "BoostAmount": 29,
-            "TaroAmount": 81,
-            "FMAmount": 102
-        },
-        "57": {
-            "MiscDropTypeID": 57,
-            "PotionAmount": 30,
-            "BoostAmount": 30,
-            "TaroAmount": 28,
-            "FMAmount": 36
-        },
-        "58": {
-            "MiscDropTypeID": 58,
-            "PotionAmount": 30,
-            "BoostAmount": 30,
-            "TaroAmount": 84,
-            "FMAmount": 108
-        },
-        "59": {
-            "MiscDropTypeID": 59,
-            "PotionAmount": 30,
-            "BoostAmount": 30,
-            "TaroAmount": 64,
-            "FMAmount": 49
-        },
-        "60": {
-            "MiscDropTypeID": 60,
-            "PotionAmount": 31,
-            "BoostAmount": 31,
-            "TaroAmount": 66,
-            "FMAmount": 52
-        },
-        "61": {
-            "MiscDropTypeID": 61,
-            "PotionAmount": 31,
-            "BoostAmount": 31,
-            "TaroAmount": 87,
-            "FMAmount": 114
-        },
-        "62": {
-            "MiscDropTypeID": 62,
-            "PotionAmount": 32,
-            "BoostAmount": 32,
-            "TaroAmount": 68,
-            "FMAmount": 55
-        },
-        "63": {
-            "MiscDropTypeID": 63,
-            "PotionAmount": 33,
-            "BoostAmount": 33,
-            "TaroAmount": 31,
-            "FMAmount": 46
-        },
-        "64": {
-            "MiscDropTypeID": 64,
-            "PotionAmount": 33,
-            "BoostAmount": 33,
-            "TaroAmount": 94,
-            "FMAmount": 138
-        },
-        "65": {
-            "MiscDropTypeID": 65,
-            "PotionAmount": 33,
-            "BoostAmount": 33,
-            "TaroAmount": 70,
-            "FMAmount": 58
-        },
-        "66": {
-            "MiscDropTypeID": 66,
-            "PotionAmount": 34,
-            "BoostAmount": 34,
-            "TaroAmount": 72,
-            "FMAmount": 61
-        },
-        "67": {
-            "MiscDropTypeID": 67,
-            "PotionAmount": 34,
-            "BoostAmount": 34,
-            "TaroAmount": 96,
-            "FMAmount": 150
-        },
-        "68": {
-            "MiscDropTypeID": 68,
-            "PotionAmount": 35,
-            "BoostAmount": 35,
-            "TaroAmount": 74,
-            "FMAmount": 64
-        },
-        "69": {
-            "MiscDropTypeID": 69,
-            "PotionAmount": 35,
-            "BoostAmount": 35,
-            "TaroAmount": 99,
-            "FMAmount": 162
-        },
-        "70": {
-            "MiscDropTypeID": 70,
-            "PotionAmount": 36,
-            "BoostAmount": 36,
-            "TaroAmount": 34,
-            "FMAmount": 58
-        },
-        "71": {
-            "MiscDropTypeID": 71,
-            "PotionAmount": 36,
-            "BoostAmount": 36,
-            "TaroAmount": 102,
-            "FMAmount": 174
-        },
-        "72": {
-            "MiscDropTypeID": 72,
-            "PotionAmount": 36,
-            "BoostAmount": 36,
-            "TaroAmount": 76,
-            "FMAmount": 68
-        },
-        "73": {
-            "MiscDropTypeID": 73,
-            "PotionAmount": 37,
-            "BoostAmount": 37,
-            "TaroAmount": 78,
-            "FMAmount": 72
-        },
-        "74": {
-            "MiscDropTypeID": 74,
-            "PotionAmount": 37,
-            "BoostAmount": 37,
-            "TaroAmount": 105,
-            "FMAmount": 186
-        },
-        "75": {
-            "MiscDropTypeID": 75,
-            "PotionAmount": 38,
-            "BoostAmount": 38,
-            "TaroAmount": 80,
-            "FMAmount": 76
-        },
-        "76": {
-            "MiscDropTypeID": 76,
-            "PotionAmount": 38,
-            "BoostAmount": 38,
-            "TaroAmount": 108,
-            "FMAmount": 198
-        },
-        "77": {
-            "MiscDropTypeID": 77,
-            "PotionAmount": 39,
-            "BoostAmount": 39,
-            "TaroAmount": 36,
-            "FMAmount": 70
-        },
-        "78": {
-            "MiscDropTypeID": 78,
-            "PotionAmount": 39,
-            "BoostAmount": 39,
-            "TaroAmount": 82,
-            "FMAmount": 80
-        },
-        "79": {
-            "MiscDropTypeID": 79,
-            "PotionAmount": 39,
-            "BoostAmount": 39,
-            "TaroAmount": 108,
-            "FMAmount": 210
-        },
-        "80": {
-            "MiscDropTypeID": 80,
-            "PotionAmount": 39,
-            "BoostAmount": 39,
-            "TaroAmount": 84,
-            "FMAmount": 85
-        },
-        "81": {
-            "MiscDropTypeID": 81,
-            "PotionAmount": 39,
-            "BoostAmount": 39,
-            "TaroAmount": 126,
-            "FMAmount": 222
-        },
-        "82": {
-            "MiscDropTypeID": 82,
-            "PotionAmount": 40,
-            "BoostAmount": 40,
-            "TaroAmount": 86,
-            "FMAmount": 90
-        },
-        "83": {
-            "MiscDropTypeID": 83,
-            "PotionAmount": 40,
-            "BoostAmount": 40,
-            "TaroAmount": 144,
-            "FMAmount": 234
-        },
-        "84": {
-            "MiscDropTypeID": 84,
-            "PotionAmount": 17,
-            "BoostAmount": 17,
-            "TaroAmount": 50,
-            "FMAmount": 44
-        },
-        "85": {
-            "MiscDropTypeID": 85,
             "PotionAmount": 18,
             "BoostAmount": 18,
             "TaroAmount": 17,
             "FMAmount": 15
         },
-        "86": {
-            "MiscDropTypeID": 86,
+        "35": {
+            "MiscDropTypeID": 35,
             "PotionAmount": 18,
             "BoostAmount": 18,
-            "TaroAmount": 51,
-            "FMAmount": 45
+            "TaroAmount": 57,
+            "FMAmount": 35
         },
-        "87": {
-            "MiscDropTypeID": 87,
+        "36": {
+            "MiscDropTypeID": 36,
             "PotionAmount": 18,
             "BoostAmount": 18,
-            "TaroAmount": 51,
-            "FMAmount": 49
+            "TaroAmount": 95,
+            "FMAmount": 28
         },
-        "88": {
-            "MiscDropTypeID": 88,
+        "37": {
+            "MiscDropTypeID": 37,
             "PotionAmount": 18,
             "BoostAmount": 18,
             "TaroAmount": 39,
             "FMAmount": 24
         },
-        "89": {
-            "MiscDropTypeID": 89,
+        "38": {
+            "MiscDropTypeID": 38,
+            "PotionAmount": 18,
+            "BoostAmount": 18,
+            "TaroAmount": 17,
+            "FMAmount": 16
+        },
+        "39": {
+            "MiscDropTypeID": 39,
+            "PotionAmount": 18,
+            "BoostAmount": 18,
+            "TaroAmount": 58,
+            "FMAmount": 36
+        },
+        "40": {
+            "MiscDropTypeID": 40,
+            "PotionAmount": 18,
+            "BoostAmount": 18,
+            "TaroAmount": 97,
+            "FMAmount": 29
+        },
+        "41": {
+            "MiscDropTypeID": 41,
+            "PotionAmount": 19,
+            "BoostAmount": 19,
+            "TaroAmount": 40,
+            "FMAmount": 25
+        },
+        "42": {
+            "MiscDropTypeID": 42,
+            "PotionAmount": 19,
+            "BoostAmount": 19,
+            "TaroAmount": 18,
+            "FMAmount": 16
+        },
+        "43": {
+            "MiscDropTypeID": 43,
+            "PotionAmount": 19,
+            "BoostAmount": 19,
+            "TaroAmount": 60,
+            "FMAmount": 38
+        },
+        "44": {
+            "MiscDropTypeID": 44,
+            "PotionAmount": 19,
+            "BoostAmount": 19,
+            "TaroAmount": 100,
+            "FMAmount": 30
+        },
+        "45": {
+            "MiscDropTypeID": 45,
+            "PotionAmount": 19,
+            "BoostAmount": 19,
+            "TaroAmount": 41,
+            "FMAmount": 26
+        },
+        "46": {
+            "MiscDropTypeID": 46,
+            "PotionAmount": 19,
+            "BoostAmount": 19,
+            "TaroAmount": 18,
+            "FMAmount": 17
+        },
+        "47": {
+            "MiscDropTypeID": 47,
+            "PotionAmount": 19,
+            "BoostAmount": 19,
+            "TaroAmount": 61,
+            "FMAmount": 39
+        },
+        "48": {
+            "MiscDropTypeID": 48,
+            "PotionAmount": 19,
+            "BoostAmount": 19,
+            "TaroAmount": 102,
+            "FMAmount": 31
+        },
+        "49": {
+            "MiscDropTypeID": 49,
+            "PotionAmount": 20,
+            "BoostAmount": 20,
+            "TaroAmount": 42,
+            "FMAmount": 27
+        },
+        "50": {
+            "MiscDropTypeID": 50,
+            "PotionAmount": 20,
+            "BoostAmount": 20,
+            "TaroAmount": 18,
+            "FMAmount": 18
+        },
+        "51": {
+            "MiscDropTypeID": 51,
+            "PotionAmount": 20,
+            "BoostAmount": 20,
+            "TaroAmount": 63,
+            "FMAmount": 41
+        },
+        "52": {
+            "MiscDropTypeID": 52,
+            "PotionAmount": 20,
+            "BoostAmount": 20,
+            "TaroAmount": 105,
+            "FMAmount": 32
+        },
+        "53": {
+            "MiscDropTypeID": 53,
+            "PotionAmount": 20,
+            "BoostAmount": 20,
+            "TaroAmount": 43,
+            "FMAmount": 28
+        },
+        "54": {
+            "MiscDropTypeID": 54,
+            "PotionAmount": 20,
+            "BoostAmount": 20,
+            "TaroAmount": 19,
+            "FMAmount": 18
+        },
+        "55": {
+            "MiscDropTypeID": 55,
+            "PotionAmount": 20,
+            "BoostAmount": 20,
+            "TaroAmount": 64,
+            "FMAmount": 42
+        },
+        "56": {
+            "MiscDropTypeID": 56,
+            "PotionAmount": 20,
+            "BoostAmount": 20,
+            "TaroAmount": 107,
+            "FMAmount": 34
+        },
+        "57": {
+            "MiscDropTypeID": 57,
+            "PotionAmount": 20,
+            "BoostAmount": 20,
+            "TaroAmount": 44,
+            "FMAmount": 29
+        },
+        "58": {
+            "MiscDropTypeID": 58,
+            "PotionAmount": 20,
+            "BoostAmount": 20,
+            "TaroAmount": 19,
+            "FMAmount": 19
+        },
+        "59": {
+            "MiscDropTypeID": 59,
+            "PotionAmount": 20,
+            "BoostAmount": 20,
+            "TaroAmount": 66,
+            "FMAmount": 44
+        },
+        "60": {
+            "MiscDropTypeID": 60,
+            "PotionAmount": 20,
+            "BoostAmount": 20,
+            "TaroAmount": 110,
+            "FMAmount": 35
+        },
+        "61": {
+            "MiscDropTypeID": 61,
+            "PotionAmount": 21,
+            "BoostAmount": 21,
+            "TaroAmount": 46,
+            "FMAmount": 30
+        },
+        "62": {
+            "MiscDropTypeID": 62,
             "PotionAmount": 21,
             "BoostAmount": 21,
             "TaroAmount": 20,
-            "FMAmount": 20
+            "FMAmount": 19
         },
-        "90": {
-            "MiscDropTypeID": 90,
+        "63": {
+            "MiscDropTypeID": 63,
+            "PotionAmount": 21,
+            "BoostAmount": 21,
+            "TaroAmount": 69,
+            "FMAmount": 45
+        },
+        "64": {
+            "MiscDropTypeID": 64,
+            "PotionAmount": 21,
+            "BoostAmount": 21,
+            "TaroAmount": 115,
+            "FMAmount": 36
+        },
+        "65": {
+            "MiscDropTypeID": 65,
+            "PotionAmount": 22,
+            "BoostAmount": 22,
+            "TaroAmount": 48,
+            "FMAmount": 32
+        },
+        "66": {
+            "MiscDropTypeID": 66,
             "PotionAmount": 22,
             "BoostAmount": 22,
             "TaroAmount": 21,
             "FMAmount": 21
         },
-        "91": {
-            "MiscDropTypeID": 91,
+        "67": {
+            "MiscDropTypeID": 67,
             "PotionAmount": 22,
             "BoostAmount": 22,
-            "TaroAmount": 43,
-            "FMAmount": 43
+            "TaroAmount": 72,
+            "FMAmount": 48
         },
-        "92": {
-            "MiscDropTypeID": 92,
-            "PotionAmount": 23,
-            "BoostAmount": 23,
-            "TaroAmount": 43,
-            "FMAmount": 46
+        "68": {
+            "MiscDropTypeID": 68,
+            "PotionAmount": 22,
+            "BoostAmount": 22,
+            "TaroAmount": 120,
+            "FMAmount": 38
         },
-        "93": {
-            "MiscDropTypeID": 93,
+        "69": {
+            "MiscDropTypeID": 69,
             "PotionAmount": 23,
             "BoostAmount": 23,
             "TaroAmount": 50,
             "FMAmount": 34
         },
-        "94": {
-            "MiscDropTypeID": 94,
-            "PotionAmount": 24,
-            "BoostAmount": 24,
+        "70": {
+            "MiscDropTypeID": 70,
+            "PotionAmount": 23,
+            "BoostAmount": 23,
             "TaroAmount": 22,
-            "FMAmount": 24
+            "FMAmount": 22
         },
-        "95": {
-            "MiscDropTypeID": 95,
+        "71": {
+            "MiscDropTypeID": 71,
+            "PotionAmount": 23,
+            "BoostAmount": 23,
+            "TaroAmount": 75,
+            "FMAmount": 51
+        },
+        "72": {
+            "MiscDropTypeID": 72,
+            "PotionAmount": 23,
+            "BoostAmount": 23,
+            "TaroAmount": 125,
+            "FMAmount": 41
+        },
+        "73": {
+            "MiscDropTypeID": 73,
             "PotionAmount": 24,
             "BoostAmount": 24,
-            "TaroAmount": 46,
-            "FMAmount": 52
+            "TaroAmount": 52,
+            "FMAmount": 36
         },
-        "96": {
-            "MiscDropTypeID": 96,
+        "74": {
+            "MiscDropTypeID": 74,
+            "PotionAmount": 24,
+            "BoostAmount": 24,
+            "TaroAmount": 23,
+            "FMAmount": 23
+        },
+        "75": {
+            "MiscDropTypeID": 75,
+            "PotionAmount": 24,
+            "BoostAmount": 24,
+            "TaroAmount": 78,
+            "FMAmount": 54
+        },
+        "76": {
+            "MiscDropTypeID": 76,
+            "PotionAmount": 24,
+            "BoostAmount": 24,
+            "TaroAmount": 130,
+            "FMAmount": 43
+        },
+        "77": {
+            "MiscDropTypeID": 77,
             "PotionAmount": 25,
             "BoostAmount": 25,
-            "TaroAmount": 23,
+            "TaroAmount": 54,
+            "FMAmount": 38
+        },
+        "78": {
+            "MiscDropTypeID": 78,
+            "PotionAmount": 25,
+            "BoostAmount": 25,
+            "TaroAmount": 24,
+            "FMAmount": 25
+        },
+        "79": {
+            "MiscDropTypeID": 79,
+            "PotionAmount": 25,
+            "BoostAmount": 25,
+            "TaroAmount": 81,
+            "FMAmount": 57
+        },
+        "80": {
+            "MiscDropTypeID": 80,
+            "PotionAmount": 25,
+            "BoostAmount": 25,
+            "TaroAmount": 135,
+            "FMAmount": 46
+        },
+        "81": {
+            "MiscDropTypeID": 81,
+            "PotionAmount": 26,
+            "BoostAmount": 26,
+            "TaroAmount": 56,
+            "FMAmount": 40
+        },
+        "82": {
+            "MiscDropTypeID": 82,
+            "PotionAmount": 26,
+            "BoostAmount": 26,
+            "TaroAmount": 25,
             "FMAmount": 26
         },
-        "97": {
-            "MiscDropTypeID": 97,
+        "83": {
+            "MiscDropTypeID": 83,
             "PotionAmount": 26,
             "BoostAmount": 26,
-            "TaroAmount": 24,
-            "FMAmount": 28
+            "TaroAmount": 84,
+            "FMAmount": 60
         },
-        "98": {
-            "MiscDropTypeID": 98,
+        "84": {
+            "MiscDropTypeID": 84,
             "PotionAmount": 26,
             "BoostAmount": 26,
-            "TaroAmount": 72,
-            "FMAmount": 86
+            "TaroAmount": 140,
+            "FMAmount": 48
         },
-        "99": {
-            "MiscDropTypeID": 99,
+        "85": {
+            "MiscDropTypeID": 85,
             "PotionAmount": 27,
             "BoostAmount": 27,
-            "TaroAmount": 25,
-            "FMAmount": 30
+            "TaroAmount": 58,
+            "FMAmount": 42
         },
-        "100": {
-            "MiscDropTypeID": 100,
+        "86": {
+            "MiscDropTypeID": 86,
+            "PotionAmount": 27,
+            "BoostAmount": 27,
+            "TaroAmount": 26,
+            "FMAmount": 27
+        },
+        "87": {
+            "MiscDropTypeID": 87,
+            "PotionAmount": 27,
+            "BoostAmount": 27,
+            "TaroAmount": 87,
+            "FMAmount": 63
+        },
+        "88": {
+            "MiscDropTypeID": 88,
+            "PotionAmount": 27,
+            "BoostAmount": 27,
+            "TaroAmount": 145,
+            "FMAmount": 50
+        },
+        "89": {
+            "MiscDropTypeID": 89,
             "PotionAmount": 28,
             "BoostAmount": 28,
-            "TaroAmount": 26,
-            "FMAmount": 32
+            "TaroAmount": 60,
+            "FMAmount": 44
         },
-        "101": {
-            "MiscDropTypeID": 101,
+        "90": {
+            "MiscDropTypeID": 90,
+            "PotionAmount": 28,
+            "BoostAmount": 28,
+            "TaroAmount": 27,
+            "FMAmount": 29
+        },
+        "91": {
+            "MiscDropTypeID": 91,
+            "PotionAmount": 28,
+            "BoostAmount": 28,
+            "TaroAmount": 90,
+            "FMAmount": 66
+        },
+        "92": {
+            "MiscDropTypeID": 92,
+            "PotionAmount": 28,
+            "BoostAmount": 28,
+            "TaroAmount": 150,
+            "FMAmount": 53
+        },
+        "93": {
+            "MiscDropTypeID": 93,
+            "PotionAmount": 29,
+            "BoostAmount": 29,
+            "TaroAmount": 62,
+            "FMAmount": 46
+        },
+        "94": {
+            "MiscDropTypeID": 94,
             "PotionAmount": 29,
             "BoostAmount": 29,
             "TaroAmount": 27,
-            "FMAmount": 34
+            "FMAmount": 30
+        },
+        "95": {
+            "MiscDropTypeID": 95,
+            "PotionAmount": 29,
+            "BoostAmount": 29,
+            "TaroAmount": 93,
+            "FMAmount": 69
+        },
+        "96": {
+            "MiscDropTypeID": 96,
+            "PotionAmount": 29,
+            "BoostAmount": 29,
+            "TaroAmount": 155,
+            "FMAmount": 55
+        },
+        "97": {
+            "MiscDropTypeID": 97,
+            "PotionAmount": 30,
+            "BoostAmount": 30,
+            "TaroAmount": 64,
+            "FMAmount": 49
+        },
+        "98": {
+            "MiscDropTypeID": 98,
+            "PotionAmount": 30,
+            "BoostAmount": 30,
+            "TaroAmount": 28,
+            "FMAmount": 32
+        },
+        "99": {
+            "MiscDropTypeID": 99,
+            "PotionAmount": 30,
+            "BoostAmount": 30,
+            "TaroAmount": 96,
+            "FMAmount": 74
+        },
+        "100": {
+            "MiscDropTypeID": 100,
+            "PotionAmount": 30,
+            "BoostAmount": 30,
+            "TaroAmount": 160,
+            "FMAmount": 59
+        },
+        "101": {
+            "MiscDropTypeID": 101,
+            "PotionAmount": 31,
+            "BoostAmount": 31,
+            "TaroAmount": 66,
+            "FMAmount": 52
         },
         "102": {
             "MiscDropTypeID": 102,
             "PotionAmount": 31,
             "BoostAmount": 31,
             "TaroAmount": 29,
-            "FMAmount": 38
+            "FMAmount": 34
         },
         "103": {
             "MiscDropTypeID": 103,
-            "PotionAmount": 32,
-            "BoostAmount": 32,
-            "TaroAmount": 90,
-            "FMAmount": 126
+            "PotionAmount": 31,
+            "BoostAmount": 31,
+            "TaroAmount": 99,
+            "FMAmount": 78
         },
         "104": {
             "MiscDropTypeID": 104,
-            "PotionAmount": 33,
-            "BoostAmount": 33,
-            "TaroAmount": 93,
-            "FMAmount": 138
+            "PotionAmount": 31,
+            "BoostAmount": 31,
+            "TaroAmount": 165,
+            "FMAmount": 62
         },
         "105": {
             "MiscDropTypeID": 105,
-            "PotionAmount": 35,
-            "BoostAmount": 35,
-            "TaroAmount": 99,
-            "FMAmount": 164
+            "PotionAmount": 32,
+            "BoostAmount": 32,
+            "TaroAmount": 68,
+            "FMAmount": 55
         },
         "106": {
             "MiscDropTypeID": 106,
-            "PotionAmount": 37,
-            "BoostAmount": 37,
-            "TaroAmount": 105,
-            "FMAmount": 195
-        },
-        "107": {
-            "MiscDropTypeID": 107,
-            "PotionAmount": 38,
-            "BoostAmount": 38,
-            "TaroAmount": 36,
-            "FMAmount": 66
-        },
-        "108": {
-            "MiscDropTypeID": 108,
-            "PotionAmount": 38,
-            "BoostAmount": 38,
-            "TaroAmount": 108,
-            "FMAmount": 210
-        },
-        "109": {
-            "MiscDropTypeID": 109,
-            "PotionAmount": 39,
-            "BoostAmount": 39,
-            "TaroAmount": 42,
-            "FMAmount": 74
-        },
-        "110": {
-            "MiscDropTypeID": 110,
-            "PotionAmount": 40,
-            "BoostAmount": 40,
-            "TaroAmount": 48,
-            "FMAmount": 78
-        },
-        "111": {
-            "MiscDropTypeID": 111,
-            "PotionAmount": 21,
-            "BoostAmount": 21,
-            "TaroAmount": 43,
-            "FMAmount": 28
-        },
-        "112": {
-            "MiscDropTypeID": 112,
-            "PotionAmount": 21,
-            "BoostAmount": 21,
-            "TaroAmount": 57,
-            "FMAmount": 54
-        },
-        "113": {
-            "MiscDropTypeID": 113,
-            "PotionAmount": 29,
-            "BoostAmount": 29,
-            "TaroAmount": 81,
-            "FMAmount": 93
-        },
-        "114": {
-            "MiscDropTypeID": 114,
             "PotionAmount": 32,
             "BoostAmount": 32,
             "TaroAmount": 30,
-            "FMAmount": 42
+            "FMAmount": 36
+        },
+        "107": {
+            "MiscDropTypeID": 107,
+            "PotionAmount": 32,
+            "BoostAmount": 32,
+            "TaroAmount": 102,
+            "FMAmount": 83
+        },
+        "108": {
+            "MiscDropTypeID": 108,
+            "PotionAmount": 32,
+            "BoostAmount": 32,
+            "TaroAmount": 170,
+            "FMAmount": 66
+        },
+        "109": {
+            "MiscDropTypeID": 109,
+            "PotionAmount": 33,
+            "BoostAmount": 33,
+            "TaroAmount": 70,
+            "FMAmount": 58
+        },
+        "110": {
+            "MiscDropTypeID": 110,
+            "PotionAmount": 33,
+            "BoostAmount": 33,
+            "TaroAmount": 31,
+            "FMAmount": 38
+        },
+        "111": {
+            "MiscDropTypeID": 111,
+            "PotionAmount": 33,
+            "BoostAmount": 33,
+            "TaroAmount": 105,
+            "FMAmount": 87
+        },
+        "112": {
+            "MiscDropTypeID": 112,
+            "PotionAmount": 33,
+            "BoostAmount": 33,
+            "TaroAmount": 175,
+            "FMAmount": 70
+        },
+        "113": {
+            "MiscDropTypeID": 113,
+            "PotionAmount": 34,
+            "BoostAmount": 34,
+            "TaroAmount": 72,
+            "FMAmount": 61
+        },
+        "114": {
+            "MiscDropTypeID": 114,
+            "PotionAmount": 34,
+            "BoostAmount": 34,
+            "TaroAmount": 32,
+            "FMAmount": 40
         },
         "115": {
             "MiscDropTypeID": 115,
             "PotionAmount": 34,
             "BoostAmount": 34,
-            "TaroAmount": 33,
-            "FMAmount": 50
+            "TaroAmount": 108,
+            "FMAmount": 92
         },
         "116": {
             "MiscDropTypeID": 116,
-            "PotionAmount": 35,
-            "BoostAmount": 35,
-            "TaroAmount": 33,
-            "FMAmount": 54
+            "PotionAmount": 34,
+            "BoostAmount": 34,
+            "TaroAmount": 180,
+            "FMAmount": 73
         },
         "117": {
             "MiscDropTypeID": 117,
-            "PotionAmount": 0,
-            "BoostAmount": 0,
-            "TaroAmount": 0,
-            "FMAmount": 0
+            "PotionAmount": 35,
+            "BoostAmount": 35,
+            "TaroAmount": 74,
+            "FMAmount": 64
         },
         "118": {
             "MiscDropTypeID": 118,
-            "PotionAmount": 0,
-            "BoostAmount": 0,
-            "TaroAmount": 40,
-            "FMAmount": 36
+            "PotionAmount": 35,
+            "BoostAmount": 35,
+            "TaroAmount": 33,
+            "FMAmount": 42
         },
         "119": {
             "MiscDropTypeID": 119,
-            "PotionAmount": 0,
-            "BoostAmount": 0,
-            "TaroAmount": 70,
-            "FMAmount": 58
+            "PotionAmount": 35,
+            "BoostAmount": 35,
+            "TaroAmount": 111,
+            "FMAmount": 96
         },
         "120": {
             "MiscDropTypeID": 120,
-            "PotionAmount": 0,
-            "BoostAmount": 0,
-            "TaroAmount": 80,
-            "FMAmount": 76
+            "PotionAmount": 35,
+            "BoostAmount": 35,
+            "TaroAmount": 185,
+            "FMAmount": 77
         },
         "121": {
             "MiscDropTypeID": 121,
-            "PotionAmount": 0,
-            "BoostAmount": 0,
-            "TaroAmount": 100,
-            "FMAmount": 94
+            "PotionAmount": 36,
+            "BoostAmount": 36,
+            "TaroAmount": 76,
+            "FMAmount": 68
         },
         "122": {
             "MiscDropTypeID": 122,
+            "PotionAmount": 36,
+            "BoostAmount": 36,
+            "TaroAmount": 34,
+            "FMAmount": 44
+        },
+        "123": {
+            "MiscDropTypeID": 123,
+            "PotionAmount": 36,
+            "BoostAmount": 36,
+            "TaroAmount": 114,
+            "FMAmount": 102
+        },
+        "124": {
+            "MiscDropTypeID": 124,
+            "PotionAmount": 36,
+            "BoostAmount": 36,
+            "TaroAmount": 190,
+            "FMAmount": 82
+        },
+        "125": {
+            "MiscDropTypeID": 125,
+            "PotionAmount": 37,
+            "BoostAmount": 37,
+            "TaroAmount": 78,
+            "FMAmount": 72
+        },
+        "126": {
+            "MiscDropTypeID": 126,
+            "PotionAmount": 37,
+            "BoostAmount": 37,
+            "TaroAmount": 35,
+            "FMAmount": 47
+        },
+        "127": {
+            "MiscDropTypeID": 127,
+            "PotionAmount": 37,
+            "BoostAmount": 37,
+            "TaroAmount": 117,
+            "FMAmount": 108
+        },
+        "128": {
+            "MiscDropTypeID": 128,
+            "PotionAmount": 37,
+            "BoostAmount": 37,
+            "TaroAmount": 195,
+            "FMAmount": 86
+        },
+        "129": {
+            "MiscDropTypeID": 129,
+            "PotionAmount": 38,
+            "BoostAmount": 38,
+            "TaroAmount": 80,
+            "FMAmount": 76
+        },
+        "130": {
+            "MiscDropTypeID": 130,
+            "PotionAmount": 38,
+            "BoostAmount": 38,
+            "TaroAmount": 36,
+            "FMAmount": 49
+        },
+        "131": {
+            "MiscDropTypeID": 131,
+            "PotionAmount": 38,
+            "BoostAmount": 38,
+            "TaroAmount": 120,
+            "FMAmount": 114
+        },
+        "132": {
+            "MiscDropTypeID": 132,
+            "PotionAmount": 38,
+            "BoostAmount": 38,
+            "TaroAmount": 200,
+            "FMAmount": 91
+        },
+        "133": {
+            "MiscDropTypeID": 133,
+            "PotionAmount": 39,
+            "BoostAmount": 39,
+            "TaroAmount": 82,
+            "FMAmount": 80
+        },
+        "134": {
+            "MiscDropTypeID": 134,
+            "PotionAmount": 39,
+            "BoostAmount": 39,
+            "TaroAmount": 36,
+            "FMAmount": 52
+        },
+        "135": {
+            "MiscDropTypeID": 135,
+            "PotionAmount": 39,
+            "BoostAmount": 39,
+            "TaroAmount": 123,
+            "FMAmount": 120
+        },
+        "136": {
+            "MiscDropTypeID": 136,
+            "PotionAmount": 39,
+            "BoostAmount": 39,
+            "TaroAmount": 205,
+            "FMAmount": 96
+        },
+        "137": {
+            "MiscDropTypeID": 137,
+            "PotionAmount": 39,
+            "BoostAmount": 39,
+            "TaroAmount": 84,
+            "FMAmount": 85
+        },
+        "138": {
+            "MiscDropTypeID": 138,
+            "PotionAmount": 39,
+            "BoostAmount": 39,
+            "TaroAmount": 37,
+            "FMAmount": 55
+        },
+        "139": {
+            "MiscDropTypeID": 139,
+            "PotionAmount": 39,
+            "BoostAmount": 39,
+            "TaroAmount": 126,
+            "FMAmount": 128
+        },
+        "140": {
+            "MiscDropTypeID": 140,
+            "PotionAmount": 39,
+            "BoostAmount": 39,
+            "TaroAmount": 210,
+            "FMAmount": 102
+        },
+        "141": {
+            "MiscDropTypeID": 141,
+            "PotionAmount": 40,
+            "BoostAmount": 40,
+            "TaroAmount": 86,
+            "FMAmount": 90
+        },
+        "142": {
+            "MiscDropTypeID": 142,
+            "PotionAmount": 40,
+            "BoostAmount": 40,
+            "TaroAmount": 38,
+            "FMAmount": 58
+        },
+        "143": {
+            "MiscDropTypeID": 143,
+            "PotionAmount": 40,
+            "BoostAmount": 40,
+            "TaroAmount": 129,
+            "FMAmount": 135
+        },
+        "144": {
+            "MiscDropTypeID": 144,
+            "PotionAmount": 40,
+            "BoostAmount": 40,
+            "TaroAmount": 215,
+            "FMAmount": 108
+        },
+        "145": {
+            "MiscDropTypeID": 145,
+            "PotionAmount": 0,
+            "BoostAmount": 0,
+            "TaroAmount": 70,
+            "FMAmount": 70
+        },
+        "146": {
+            "MiscDropTypeID": 146,
+            "PotionAmount": 0,
+            "BoostAmount": 0,
+            "TaroAmount": 80,
+            "FMAmount": 80
+        },
+        "147": {
+            "MiscDropTypeID": 147,
+            "PotionAmount": 0,
+            "BoostAmount": 0,
+            "TaroAmount": 100,
+            "FMAmount": 100
+        },
+        "148": {
+            "MiscDropTypeID": 148,
             "PotionAmount": 0,
             "BoostAmount": 0,
             "TaroAmount": 140,
-            "FMAmount": 125
+            "FMAmount": 140
         }
     },
     "MobDrops": {
         "0": {
-            "MobDropID": 1,
-            "CrateDropChanceID": 0,
-            "CrateDropTypeID": 0,
-            "MiscDropChanceID": 0,
-            "MiscDropTypeID": 0
-        },
-        "1": {
-            "MobDropID": 2,
+            "MobDropID": 0,
             "CrateDropChanceID": 0,
             "CrateDropTypeID": 0,
             "MiscDropChanceID": 0,
             "MiscDropTypeID": 1
         },
-        "2": {
-            "MobDropID": 3,
+        "10": {
+            "MobDropID": 10,
             "CrateDropChanceID": 0,
             "CrateDropTypeID": 0,
             "MiscDropChanceID": 0,
             "MiscDropTypeID": 2
         },
-        "3": {
-            "MobDropID": 4,
+        "20": {
+            "MobDropID": 20,
             "CrateDropChanceID": 0,
             "CrateDropTypeID": 0,
             "MiscDropChanceID": 0,
-            "MiscDropTypeID": 1
+            "MiscDropTypeID": 3
         },
-        "4": {
-            "MobDropID": 5,
+        "21": {
+            "MobDropID": 21,
             "CrateDropChanceID": 0,
             "CrateDropTypeID": 1,
             "MiscDropChanceID": 0,
             "MiscDropTypeID": 3
         },
-        "5": {
-            "MobDropID": 6,
+        "30": {
+            "MobDropID": 30,
             "CrateDropChanceID": 0,
-            "CrateDropTypeID": 1,
+            "CrateDropTypeID": 0,
             "MiscDropChanceID": 0,
             "MiscDropTypeID": 4
         },
-        "6": {
-            "MobDropID": 7,
+        "40": {
+            "MobDropID": 40,
             "CrateDropChanceID": 0,
             "CrateDropTypeID": 1,
             "MiscDropChanceID": 0,
             "MiscDropTypeID": 5
         },
-        "7": {
-            "MobDropID": 8,
+        "50": {
+            "MobDropID": 50,
             "CrateDropChanceID": 0,
             "CrateDropTypeID": 1,
             "MiscDropChanceID": 0,
-            "MiscDropTypeID": 3
-        },
-        "8": {
-            "MobDropID": 9,
-            "CrateDropChanceID": 0,
-            "CrateDropTypeID": 2,
-            "MiscDropChanceID": 0,
             "MiscDropTypeID": 6
         },
-        "9": {
-            "MobDropID": 10,
+        "60": {
+            "MobDropID": 60,
             "CrateDropChanceID": 0,
-            "CrateDropTypeID": 2,
+            "CrateDropTypeID": 1,
             "MiscDropChanceID": 0,
             "MiscDropTypeID": 7
         },
-        "10": {
-            "MobDropID": 11,
+        "70": {
+            "MobDropID": 70,
             "CrateDropChanceID": 0,
-            "CrateDropTypeID": 2,
+            "CrateDropTypeID": 1,
             "MiscDropChanceID": 0,
             "MiscDropTypeID": 8
         },
-        "11": {
-            "MobDropID": 12,
+        "80": {
+            "MobDropID": 80,
             "CrateDropChanceID": 0,
             "CrateDropTypeID": 2,
             "MiscDropChanceID": 0,
-            "MiscDropTypeID": 7
-        },
-        "12": {
-            "MobDropID": 13,
-            "CrateDropChanceID": 0,
-            "CrateDropTypeID": 3,
-            "MiscDropChanceID": 0,
             "MiscDropTypeID": 9
         },
-        "13": {
-            "MobDropID": 14,
+        "90": {
+            "MobDropID": 90,
             "CrateDropChanceID": 0,
-            "CrateDropTypeID": 3,
+            "CrateDropTypeID": 2,
             "MiscDropChanceID": 0,
             "MiscDropTypeID": 10
         },
-        "14": {
-            "MobDropID": 15,
+        "100": {
+            "MobDropID": 100,
             "CrateDropChanceID": 0,
-            "CrateDropTypeID": 3,
+            "CrateDropTypeID": 2,
             "MiscDropChanceID": 0,
             "MiscDropTypeID": 11
         },
-        "15": {
-            "MobDropID": 17,
+        "110": {
+            "MobDropID": 110,
             "CrateDropChanceID": 0,
-            "CrateDropTypeID": 4,
+            "CrateDropTypeID": 2,
             "MiscDropChanceID": 0,
             "MiscDropTypeID": 12
         },
-        "16": {
-            "MobDropID": 18,
+        "120": {
+            "MobDropID": 120,
             "CrateDropChanceID": 0,
-            "CrateDropTypeID": 4,
+            "CrateDropTypeID": 3,
             "MiscDropChanceID": 0,
             "MiscDropTypeID": 13
         },
-        "17": {
-            "MobDropID": 19,
+        "130": {
+            "MobDropID": 130,
             "CrateDropChanceID": 0,
-            "CrateDropTypeID": 4,
+            "CrateDropTypeID": 3,
             "MiscDropChanceID": 0,
             "MiscDropTypeID": 14
         },
-        "18": {
-            "MobDropID": 20,
+        "140": {
+            "MobDropID": 140,
+            "CrateDropChanceID": 0,
+            "CrateDropTypeID": 3,
+            "MiscDropChanceID": 0,
+            "MiscDropTypeID": 15
+        },
+        "160": {
+            "MobDropID": 160,
             "CrateDropChanceID": 0,
             "CrateDropTypeID": 4,
             "MiscDropChanceID": 0,
-            "MiscDropTypeID": 14
-        },
-        "19": {
-            "MobDropID": 21,
-            "CrateDropChanceID": 0,
-            "CrateDropTypeID": 5,
-            "MiscDropChanceID": 0,
-            "MiscDropTypeID": 15
-        },
-        "20": {
-            "MobDropID": 22,
-            "CrateDropChanceID": 0,
-            "CrateDropTypeID": 5,
-            "MiscDropChanceID": 0,
-            "MiscDropTypeID": 15
-        },
-        "21": {
-            "MobDropID": 23,
-            "CrateDropChanceID": 0,
-            "CrateDropTypeID": 5,
-            "MiscDropChanceID": 0,
-            "MiscDropTypeID": 16
-        },
-        "22": {
-            "MobDropID": 24,
-            "CrateDropChanceID": 0,
-            "CrateDropTypeID": 5,
-            "MiscDropChanceID": 0,
-            "MiscDropTypeID": 16
-        },
-        "23": {
-            "MobDropID": 25,
-            "CrateDropChanceID": 0,
-            "CrateDropTypeID": 6,
-            "MiscDropChanceID": 0,
             "MiscDropTypeID": 17
         },
-        "24": {
-            "MobDropID": 26,
+        "170": {
+            "MobDropID": 170,
             "CrateDropChanceID": 0,
-            "CrateDropTypeID": 6,
-            "MiscDropChanceID": 0,
-            "MiscDropTypeID": 17
-        },
-        "25": {
-            "MobDropID": 27,
-            "CrateDropChanceID": 0,
-            "CrateDropTypeID": 6,
+            "CrateDropTypeID": 4,
             "MiscDropChanceID": 0,
             "MiscDropTypeID": 18
         },
-        "26": {
-            "MobDropID": 28,
+        "180": {
+            "MobDropID": 180,
             "CrateDropChanceID": 0,
-            "CrateDropTypeID": 6,
-            "MiscDropChanceID": 0,
-            "MiscDropTypeID": 17
-        },
-        "27": {
-            "MobDropID": 29,
-            "CrateDropChanceID": 0,
-            "CrateDropTypeID": 7,
+            "CrateDropTypeID": 4,
             "MiscDropChanceID": 0,
             "MiscDropTypeID": 19
         },
-        "28": {
-            "MobDropID": 30,
+        "190": {
+            "MobDropID": 190,
             "CrateDropChanceID": 0,
-            "CrateDropTypeID": 7,
-            "MiscDropChanceID": 0,
-            "MiscDropTypeID": 19
-        },
-        "29": {
-            "MobDropID": 31,
-            "CrateDropChanceID": 0,
-            "CrateDropTypeID": 7,
+            "CrateDropTypeID": 4,
             "MiscDropChanceID": 0,
             "MiscDropTypeID": 20
         },
-        "30": {
-            "MobDropID": 32,
+        "200": {
+            "MobDropID": 200,
             "CrateDropChanceID": 0,
-            "CrateDropTypeID": 7,
+            "CrateDropTypeID": 5,
             "MiscDropChanceID": 0,
             "MiscDropTypeID": 21
         },
-        "31": {
-            "MobDropID": 33,
+        "210": {
+            "MobDropID": 210,
             "CrateDropChanceID": 0,
-            "CrateDropTypeID": 8,
+            "CrateDropTypeID": 5,
             "MiscDropChanceID": 0,
             "MiscDropTypeID": 22
         },
-        "32": {
-            "MobDropID": 34,
+        "220": {
+            "MobDropID": 220,
             "CrateDropChanceID": 0,
-            "CrateDropTypeID": 8,
-            "MiscDropChanceID": 0,
-            "MiscDropTypeID": 22
-        },
-        "33": {
-            "MobDropID": 35,
-            "CrateDropChanceID": 0,
-            "CrateDropTypeID": 8,
+            "CrateDropTypeID": 5,
             "MiscDropChanceID": 0,
             "MiscDropTypeID": 23
         },
-        "34": {
-            "MobDropID": 36,
+        "230": {
+            "MobDropID": 230,
             "CrateDropChanceID": 0,
-            "CrateDropTypeID": 8,
-            "MiscDropChanceID": 0,
-            "MiscDropTypeID": 22
-        },
-        "35": {
-            "MobDropID": 37,
-            "CrateDropChanceID": 0,
-            "CrateDropTypeID": 9,
+            "CrateDropTypeID": 5,
             "MiscDropChanceID": 0,
             "MiscDropTypeID": 24
         },
-        "36": {
-            "MobDropID": 38,
+        "240": {
+            "MobDropID": 240,
             "CrateDropChanceID": 0,
-            "CrateDropTypeID": 9,
+            "CrateDropTypeID": 6,
             "MiscDropChanceID": 0,
             "MiscDropTypeID": 25
         },
-        "37": {
-            "MobDropID": 39,
+        "250": {
+            "MobDropID": 250,
             "CrateDropChanceID": 0,
-            "CrateDropTypeID": 9,
+            "CrateDropTypeID": 6,
             "MiscDropChanceID": 0,
             "MiscDropTypeID": 26
         },
-        "38": {
-            "MobDropID": 40,
+        "251": {
+            "MobDropID": 251,
             "CrateDropChanceID": 0,
-            "CrateDropTypeID": 9,
+            "CrateDropTypeID": 36,
             "MiscDropChanceID": 0,
-            "MiscDropTypeID": 24
+            "MiscDropTypeID": 26
         },
-        "39": {
-            "MobDropID": 41,
+        "260": {
+            "MobDropID": 260,
             "CrateDropChanceID": 0,
-            "CrateDropTypeID": 10,
-            "MiscDropChanceID": 0,
-            "MiscDropTypeID": 27
-        },
-        "40": {
-            "MobDropID": 42,
-            "CrateDropChanceID": 0,
-            "CrateDropTypeID": 10,
+            "CrateDropTypeID": 6,
             "MiscDropChanceID": 0,
             "MiscDropTypeID": 27
         },
-        "41": {
-            "MobDropID": 43,
+        "261": {
+            "MobDropID": 261,
             "CrateDropChanceID": 0,
-            "CrateDropTypeID": 10,
+            "CrateDropTypeID": 36,
+            "MiscDropChanceID": 0,
+            "MiscDropTypeID": 27
+        },
+        "270": {
+            "MobDropID": 270,
+            "CrateDropChanceID": 0,
+            "CrateDropTypeID": 6,
             "MiscDropChanceID": 0,
             "MiscDropTypeID": 28
         },
-        "42": {
-            "MobDropID": 44,
+        "280": {
+            "MobDropID": 280,
+            "CrateDropChanceID": 0,
+            "CrateDropTypeID": 7,
+            "MiscDropChanceID": 0,
+            "MiscDropTypeID": 29
+        },
+        "281": {
+            "MobDropID": 281,
+            "CrateDropChanceID": 0,
+            "CrateDropTypeID": 37,
+            "MiscDropChanceID": 0,
+            "MiscDropTypeID": 29
+        },
+        "290": {
+            "MobDropID": 290,
+            "CrateDropChanceID": 0,
+            "CrateDropTypeID": 7,
+            "MiscDropChanceID": 0,
+            "MiscDropTypeID": 30
+        },
+        "291": {
+            "MobDropID": 291,
+            "CrateDropChanceID": 0,
+            "CrateDropTypeID": 37,
+            "MiscDropChanceID": 0,
+            "MiscDropTypeID": 30
+        },
+        "300": {
+            "MobDropID": 300,
+            "CrateDropChanceID": 0,
+            "CrateDropTypeID": 7,
+            "MiscDropChanceID": 0,
+            "MiscDropTypeID": 31
+        },
+        "301": {
+            "MobDropID": 301,
+            "CrateDropChanceID": 0,
+            "CrateDropTypeID": 37,
+            "MiscDropChanceID": 0,
+            "MiscDropTypeID": 31
+        },
+        "310": {
+            "MobDropID": 310,
+            "CrateDropChanceID": 0,
+            "CrateDropTypeID": 7,
+            "MiscDropChanceID": 0,
+            "MiscDropTypeID": 32
+        },
+        "311": {
+            "MobDropID": 311,
+            "CrateDropChanceID": 0,
+            "CrateDropTypeID": 37,
+            "MiscDropChanceID": 0,
+            "MiscDropTypeID": 32
+        },
+        "320": {
+            "MobDropID": 320,
+            "CrateDropChanceID": 0,
+            "CrateDropTypeID": 8,
+            "MiscDropChanceID": 0,
+            "MiscDropTypeID": 33
+        },
+        "321": {
+            "MobDropID": 321,
+            "CrateDropChanceID": 0,
+            "CrateDropTypeID": 38,
+            "MiscDropChanceID": 0,
+            "MiscDropTypeID": 33
+        },
+        "330": {
+            "MobDropID": 330,
+            "CrateDropChanceID": 0,
+            "CrateDropTypeID": 8,
+            "MiscDropChanceID": 0,
+            "MiscDropTypeID": 34
+        },
+        "331": {
+            "MobDropID": 331,
+            "CrateDropChanceID": 0,
+            "CrateDropTypeID": 38,
+            "MiscDropChanceID": 0,
+            "MiscDropTypeID": 34
+        },
+        "340": {
+            "MobDropID": 340,
+            "CrateDropChanceID": 0,
+            "CrateDropTypeID": 8,
+            "MiscDropChanceID": 0,
+            "MiscDropTypeID": 35
+        },
+        "341": {
+            "MobDropID": 341,
+            "CrateDropChanceID": 0,
+            "CrateDropTypeID": 38,
+            "MiscDropChanceID": 0,
+            "MiscDropTypeID": 35
+        },
+        "350": {
+            "MobDropID": 350,
+            "CrateDropChanceID": 0,
+            "CrateDropTypeID": 8,
+            "MiscDropChanceID": 0,
+            "MiscDropTypeID": 36
+        },
+        "351": {
+            "MobDropID": 351,
+            "CrateDropChanceID": 0,
+            "CrateDropTypeID": 38,
+            "MiscDropChanceID": 0,
+            "MiscDropTypeID": 36
+        },
+        "360": {
+            "MobDropID": 360,
+            "CrateDropChanceID": 0,
+            "CrateDropTypeID": 9,
+            "MiscDropChanceID": 0,
+            "MiscDropTypeID": 37
+        },
+        "361": {
+            "MobDropID": 361,
+            "CrateDropChanceID": 0,
+            "CrateDropTypeID": 39,
+            "MiscDropChanceID": 0,
+            "MiscDropTypeID": 37
+        },
+        "370": {
+            "MobDropID": 370,
+            "CrateDropChanceID": 0,
+            "CrateDropTypeID": 9,
+            "MiscDropChanceID": 0,
+            "MiscDropTypeID": 38
+        },
+        "371": {
+            "MobDropID": 371,
+            "CrateDropChanceID": 0,
+            "CrateDropTypeID": 39,
+            "MiscDropChanceID": 0,
+            "MiscDropTypeID": 38
+        },
+        "380": {
+            "MobDropID": 380,
+            "CrateDropChanceID": 0,
+            "CrateDropTypeID": 9,
+            "MiscDropChanceID": 0,
+            "MiscDropTypeID": 39
+        },
+        "381": {
+            "MobDropID": 381,
+            "CrateDropChanceID": 0,
+            "CrateDropTypeID": 39,
+            "MiscDropChanceID": 0,
+            "MiscDropTypeID": 39
+        },
+        "390": {
+            "MobDropID": 390,
+            "CrateDropChanceID": 0,
+            "CrateDropTypeID": 9,
+            "MiscDropChanceID": 0,
+            "MiscDropTypeID": 40
+        },
+        "391": {
+            "MobDropID": 391,
+            "CrateDropChanceID": 0,
+            "CrateDropTypeID": 39,
+            "MiscDropChanceID": 0,
+            "MiscDropTypeID": 40
+        },
+        "400": {
+            "MobDropID": 400,
             "CrateDropChanceID": 0,
             "CrateDropTypeID": 10,
             "MiscDropChanceID": 0,
-            "MiscDropTypeID": 27
+            "MiscDropTypeID": 41
         },
-        "43": {
-            "MobDropID": 45,
+        "401": {
+            "MobDropID": 401,
             "CrateDropChanceID": 0,
-            "CrateDropTypeID": 11,
-            "MiscDropChanceID": 0,
-            "MiscDropTypeID": 29
-        },
-        "44": {
-            "MobDropID": 46,
-            "CrateDropChanceID": 0,
-            "CrateDropTypeID": 11,
-            "MiscDropChanceID": 0,
-            "MiscDropTypeID": 29
-        },
-        "45": {
-            "MobDropID": 47,
-            "CrateDropChanceID": 0,
-            "CrateDropTypeID": 11,
-            "MiscDropChanceID": 0,
-            "MiscDropTypeID": 30
-        },
-        "46": {
-            "MobDropID": 48,
-            "CrateDropChanceID": 0,
-            "CrateDropTypeID": 11,
-            "MiscDropChanceID": 0,
-            "MiscDropTypeID": 31
-        },
-        "47": {
-            "MobDropID": 49,
-            "CrateDropChanceID": 0,
-            "CrateDropTypeID": 12,
-            "MiscDropChanceID": 0,
-            "MiscDropTypeID": 32
-        },
-        "48": {
-            "MobDropID": 50,
-            "CrateDropChanceID": 0,
-            "CrateDropTypeID": 12,
-            "MiscDropChanceID": 0,
-            "MiscDropTypeID": 32
-        },
-        "49": {
-            "MobDropID": 51,
-            "CrateDropChanceID": 0,
-            "CrateDropTypeID": 12,
-            "MiscDropChanceID": 0,
-            "MiscDropTypeID": 33
-        },
-        "50": {
-            "MobDropID": 52,
-            "CrateDropChanceID": 0,
-            "CrateDropTypeID": 12,
-            "MiscDropChanceID": 0,
-            "MiscDropTypeID": 34
-        },
-        "51": {
-            "MobDropID": 53,
-            "CrateDropChanceID": 0,
-            "CrateDropTypeID": 13,
-            "MiscDropChanceID": 0,
-            "MiscDropTypeID": 35
-        },
-        "52": {
-            "MobDropID": 54,
-            "CrateDropChanceID": 0,
-            "CrateDropTypeID": 13,
-            "MiscDropChanceID": 0,
-            "MiscDropTypeID": 35
-        },
-        "53": {
-            "MobDropID": 55,
-            "CrateDropChanceID": 0,
-            "CrateDropTypeID": 13,
-            "MiscDropChanceID": 0,
-            "MiscDropTypeID": 33
-        },
-        "54": {
-            "MobDropID": 56,
-            "CrateDropChanceID": 0,
-            "CrateDropTypeID": 13,
-            "MiscDropChanceID": 0,
-            "MiscDropTypeID": 35
-        },
-        "55": {
-            "MobDropID": 57,
-            "CrateDropChanceID": 0,
-            "CrateDropTypeID": 14,
-            "MiscDropChanceID": 0,
-            "MiscDropTypeID": 36
-        },
-        "56": {
-            "MobDropID": 58,
-            "CrateDropChanceID": 0,
-            "CrateDropTypeID": 14,
-            "MiscDropChanceID": 0,
-            "MiscDropTypeID": 36
-        },
-        "57": {
-            "MobDropID": 59,
-            "CrateDropChanceID": 0,
-            "CrateDropTypeID": 14,
-            "MiscDropChanceID": 0,
-            "MiscDropTypeID": 37
-        },
-        "58": {
-            "MobDropID": 60,
-            "CrateDropChanceID": 0,
-            "CrateDropTypeID": 14,
-            "MiscDropChanceID": 0,
-            "MiscDropTypeID": 38
-        },
-        "59": {
-            "MobDropID": 61,
-            "CrateDropChanceID": 0,
-            "CrateDropTypeID": 15,
-            "MiscDropChanceID": 0,
-            "MiscDropTypeID": 39
-        },
-        "60": {
-            "MobDropID": 62,
-            "CrateDropChanceID": 0,
-            "CrateDropTypeID": 15,
-            "MiscDropChanceID": 0,
-            "MiscDropTypeID": 39
-        },
-        "61": {
-            "MobDropID": 63,
-            "CrateDropChanceID": 0,
-            "CrateDropTypeID": 15,
-            "MiscDropChanceID": 0,
-            "MiscDropTypeID": 40
-        },
-        "62": {
-            "MobDropID": 64,
-            "CrateDropChanceID": 0,
-            "CrateDropTypeID": 15,
-            "MiscDropChanceID": 0,
-            "MiscDropTypeID": 39
-        },
-        "63": {
-            "MobDropID": 65,
-            "CrateDropChanceID": 0,
-            "CrateDropTypeID": 16,
+            "CrateDropTypeID": 40,
             "MiscDropChanceID": 0,
             "MiscDropTypeID": 41
         },
-        "64": {
-            "MobDropID": 66,
+        "402": {
+            "MobDropID": 402,
             "CrateDropChanceID": 0,
-            "CrateDropTypeID": 16,
+            "CrateDropTypeID": 66,
             "MiscDropChanceID": 0,
             "MiscDropTypeID": 41
         },
-        "65": {
-            "MobDropID": 67,
+        "410": {
+            "MobDropID": 410,
             "CrateDropChanceID": 0,
-            "CrateDropTypeID": 16,
+            "CrateDropTypeID": 10,
             "MiscDropChanceID": 0,
             "MiscDropTypeID": 42
         },
-        "66": {
-            "MobDropID": 68,
+        "411": {
+            "MobDropID": 411,
             "CrateDropChanceID": 0,
-            "CrateDropTypeID": 16,
+            "CrateDropTypeID": 40,
             "MiscDropChanceID": 0,
-            "MiscDropTypeID": 41
+            "MiscDropTypeID": 42
         },
-        "67": {
-            "MobDropID": 69,
+        "412": {
+            "MobDropID": 412,
             "CrateDropChanceID": 0,
-            "CrateDropTypeID": 17,
+            "CrateDropTypeID": 66,
+            "MiscDropChanceID": 0,
+            "MiscDropTypeID": 42
+        },
+        "420": {
+            "MobDropID": 420,
+            "CrateDropChanceID": 0,
+            "CrateDropTypeID": 10,
             "MiscDropChanceID": 0,
             "MiscDropTypeID": 43
         },
-        "68": {
-            "MobDropID": 70,
+        "421": {
+            "MobDropID": 421,
             "CrateDropChanceID": 0,
-            "CrateDropTypeID": 17,
+            "CrateDropTypeID": 40,
             "MiscDropChanceID": 0,
             "MiscDropTypeID": 43
         },
-        "69": {
-            "MobDropID": 71,
+        "422": {
+            "MobDropID": 422,
             "CrateDropChanceID": 0,
-            "CrateDropTypeID": 17,
+            "CrateDropTypeID": 66,
+            "MiscDropChanceID": 0,
+            "MiscDropTypeID": 43
+        },
+        "430": {
+            "MobDropID": 430,
+            "CrateDropChanceID": 0,
+            "CrateDropTypeID": 10,
             "MiscDropChanceID": 0,
             "MiscDropTypeID": 44
         },
-        "70": {
-            "MobDropID": 72,
+        "431": {
+            "MobDropID": 431,
             "CrateDropChanceID": 0,
-            "CrateDropTypeID": 18,
+            "CrateDropTypeID": 40,
+            "MiscDropChanceID": 0,
+            "MiscDropTypeID": 44
+        },
+        "440": {
+            "MobDropID": 440,
+            "CrateDropChanceID": 0,
+            "CrateDropTypeID": 11,
             "MiscDropChanceID": 0,
             "MiscDropTypeID": 45
         },
-        "71": {
-            "MobDropID": 73,
+        "441": {
+            "MobDropID": 441,
             "CrateDropChanceID": 0,
-            "CrateDropTypeID": 18,
+            "CrateDropTypeID": 41,
             "MiscDropChanceID": 0,
             "MiscDropTypeID": 45
         },
-        "72": {
-            "MobDropID": 74,
+        "442": {
+            "MobDropID": 442,
             "CrateDropChanceID": 0,
-            "CrateDropTypeID": 18,
+            "CrateDropTypeID": 67,
             "MiscDropChanceID": 0,
             "MiscDropTypeID": 45
         },
-        "73": {
-            "MobDropID": 75,
+        "450": {
+            "MobDropID": 450,
             "CrateDropChanceID": 0,
-            "CrateDropTypeID": 18,
+            "CrateDropTypeID": 11,
             "MiscDropChanceID": 0,
             "MiscDropTypeID": 46
         },
-        "74": {
-            "MobDropID": 76,
+        "451": {
+            "MobDropID": 451,
             "CrateDropChanceID": 0,
-            "CrateDropTypeID": 18,
+            "CrateDropTypeID": 41,
             "MiscDropChanceID": 0,
-            "MiscDropTypeID": 45
+            "MiscDropTypeID": 46
         },
-        "75": {
-            "MobDropID": 77,
+        "452": {
+            "MobDropID": 452,
             "CrateDropChanceID": 0,
-            "CrateDropTypeID": 19,
+            "CrateDropTypeID": 67,
+            "MiscDropChanceID": 0,
+            "MiscDropTypeID": 46
+        },
+        "460": {
+            "MobDropID": 460,
+            "CrateDropChanceID": 0,
+            "CrateDropTypeID": 11,
             "MiscDropChanceID": 0,
             "MiscDropTypeID": 47
         },
-        "76": {
-            "MobDropID": 78,
+        "461": {
+            "MobDropID": 461,
             "CrateDropChanceID": 0,
-            "CrateDropTypeID": 19,
+            "CrateDropTypeID": 41,
             "MiscDropChanceID": 0,
             "MiscDropTypeID": 47
         },
-        "77": {
-            "MobDropID": 79,
+        "462": {
+            "MobDropID": 462,
             "CrateDropChanceID": 0,
-            "CrateDropTypeID": 19,
+            "CrateDropTypeID": 67,
+            "MiscDropChanceID": 0,
+            "MiscDropTypeID": 47
+        },
+        "470": {
+            "MobDropID": 470,
+            "CrateDropChanceID": 0,
+            "CrateDropTypeID": 11,
             "MiscDropChanceID": 0,
             "MiscDropTypeID": 48
         },
-        "78": {
-            "MobDropID": 80,
+        "471": {
+            "MobDropID": 471,
             "CrateDropChanceID": 0,
-            "CrateDropTypeID": 19,
+            "CrateDropTypeID": 41,
             "MiscDropChanceID": 0,
-            "MiscDropTypeID": 47
+            "MiscDropTypeID": 48
         },
-        "79": {
-            "MobDropID": 81,
+        "472": {
+            "MobDropID": 472,
             "CrateDropChanceID": 0,
-            "CrateDropTypeID": 20,
+            "CrateDropTypeID": 67,
+            "MiscDropChanceID": 0,
+            "MiscDropTypeID": 48
+        },
+        "480": {
+            "MobDropID": 480,
+            "CrateDropChanceID": 0,
+            "CrateDropTypeID": 12,
             "MiscDropChanceID": 0,
             "MiscDropTypeID": 49
         },
-        "80": {
-            "MobDropID": 82,
+        "481": {
+            "MobDropID": 481,
             "CrateDropChanceID": 0,
-            "CrateDropTypeID": 20,
+            "CrateDropTypeID": 42,
             "MiscDropChanceID": 0,
             "MiscDropTypeID": 49
         },
-        "81": {
-            "MobDropID": 83,
+        "482": {
+            "MobDropID": 482,
             "CrateDropChanceID": 0,
-            "CrateDropTypeID": 20,
+            "CrateDropTypeID": 68,
+            "MiscDropChanceID": 0,
+            "MiscDropTypeID": 49
+        },
+        "490": {
+            "MobDropID": 490,
+            "CrateDropChanceID": 0,
+            "CrateDropTypeID": 12,
             "MiscDropChanceID": 0,
             "MiscDropTypeID": 50
         },
-        "82": {
-            "MobDropID": 84,
+        "491": {
+            "MobDropID": 491,
             "CrateDropChanceID": 0,
-            "CrateDropTypeID": 20,
+            "CrateDropTypeID": 42,
             "MiscDropChanceID": 0,
-            "MiscDropTypeID": 49
+            "MiscDropTypeID": 50
         },
-        "83": {
-            "MobDropID": 85,
+        "492": {
+            "MobDropID": 492,
             "CrateDropChanceID": 0,
-            "CrateDropTypeID": 21,
+            "CrateDropTypeID": 68,
+            "MiscDropChanceID": 0,
+            "MiscDropTypeID": 50
+        },
+        "500": {
+            "MobDropID": 500,
+            "CrateDropChanceID": 0,
+            "CrateDropTypeID": 12,
             "MiscDropChanceID": 0,
             "MiscDropTypeID": 51
         },
-        "84": {
-            "MobDropID": 86,
+        "501": {
+            "MobDropID": 501,
             "CrateDropChanceID": 0,
-            "CrateDropTypeID": 21,
+            "CrateDropTypeID": 42,
             "MiscDropChanceID": 0,
             "MiscDropTypeID": 51
         },
-        "85": {
-            "MobDropID": 87,
+        "502": {
+            "MobDropID": 502,
             "CrateDropChanceID": 0,
-            "CrateDropTypeID": 21,
+            "CrateDropTypeID": 68,
+            "MiscDropChanceID": 0,
+            "MiscDropTypeID": 51
+        },
+        "510": {
+            "MobDropID": 510,
+            "CrateDropChanceID": 0,
+            "CrateDropTypeID": 12,
             "MiscDropChanceID": 0,
             "MiscDropTypeID": 52
         },
-        "86": {
-            "MobDropID": 88,
+        "511": {
+            "MobDropID": 511,
             "CrateDropChanceID": 0,
-            "CrateDropTypeID": 21,
+            "CrateDropTypeID": 42,
             "MiscDropChanceID": 0,
-            "MiscDropTypeID": 51
+            "MiscDropTypeID": 52
         },
-        "87": {
-            "MobDropID": 89,
+        "512": {
+            "MobDropID": 512,
             "CrateDropChanceID": 0,
-            "CrateDropTypeID": 22,
+            "CrateDropTypeID": 68,
+            "MiscDropChanceID": 0,
+            "MiscDropTypeID": 52
+        },
+        "520": {
+            "MobDropID": 520,
+            "CrateDropChanceID": 0,
+            "CrateDropTypeID": 13,
             "MiscDropChanceID": 0,
             "MiscDropTypeID": 53
         },
-        "88": {
-            "MobDropID": 90,
+        "521": {
+            "MobDropID": 521,
             "CrateDropChanceID": 0,
-            "CrateDropTypeID": 22,
+            "CrateDropTypeID": 43,
             "MiscDropChanceID": 0,
             "MiscDropTypeID": 53
         },
-        "89": {
-            "MobDropID": 91,
+        "530": {
+            "MobDropID": 530,
             "CrateDropChanceID": 0,
-            "CrateDropTypeID": 22,
+            "CrateDropTypeID": 43,
             "MiscDropChanceID": 0,
             "MiscDropTypeID": 54
         },
-        "90": {
-            "MobDropID": 92,
+        "531": {
+            "MobDropID": 531,
             "CrateDropChanceID": 0,
-            "CrateDropTypeID": 22,
+            "CrateDropTypeID": 69,
             "MiscDropChanceID": 0,
-            "MiscDropTypeID": 53
+            "MiscDropTypeID": 54
         },
-        "91": {
-            "MobDropID": 93,
+        "540": {
+            "MobDropID": 540,
             "CrateDropChanceID": 0,
-            "CrateDropTypeID": 23,
-            "MiscDropChanceID": 0,
-            "MiscDropTypeID": 55
-        },
-        "92": {
-            "MobDropID": 94,
-            "CrateDropChanceID": 0,
-            "CrateDropTypeID": 23,
+            "CrateDropTypeID": 13,
             "MiscDropChanceID": 0,
             "MiscDropTypeID": 55
         },
-        "93": {
-            "MobDropID": 95,
+        "541": {
+            "MobDropID": 541,
             "CrateDropChanceID": 0,
-            "CrateDropTypeID": 23,
+            "CrateDropTypeID": 43,
+            "MiscDropChanceID": 0,
+            "MiscDropTypeID": 55
+        },
+        "542": {
+            "MobDropID": 542,
+            "CrateDropChanceID": 0,
+            "CrateDropTypeID": 69,
+            "MiscDropChanceID": 0,
+            "MiscDropTypeID": 55
+        },
+        "550": {
+            "MobDropID": 550,
+            "CrateDropChanceID": 0,
+            "CrateDropTypeID": 43,
             "MiscDropChanceID": 0,
             "MiscDropTypeID": 56
         },
-        "94": {
-            "MobDropID": 96,
+        "560": {
+            "MobDropID": 560,
             "CrateDropChanceID": 0,
-            "CrateDropTypeID": 23,
-            "MiscDropChanceID": 0,
-            "MiscDropTypeID": 55
-        },
-        "95": {
-            "MobDropID": 97,
-            "CrateDropChanceID": 0,
-            "CrateDropTypeID": 24,
+            "CrateDropTypeID": 14,
             "MiscDropChanceID": 0,
             "MiscDropTypeID": 57
         },
-        "96": {
-            "MobDropID": 98,
+        "561": {
+            "MobDropID": 561,
             "CrateDropChanceID": 0,
-            "CrateDropTypeID": 24,
+            "CrateDropTypeID": 44,
             "MiscDropChanceID": 0,
             "MiscDropTypeID": 57
         },
-        "97": {
-            "MobDropID": 99,
+        "562": {
+            "MobDropID": 562,
             "CrateDropChanceID": 0,
-            "CrateDropTypeID": 24,
+            "CrateDropTypeID": 70,
+            "MiscDropChanceID": 0,
+            "MiscDropTypeID": 57
+        },
+        "570": {
+            "MobDropID": 570,
+            "CrateDropChanceID": 0,
+            "CrateDropTypeID": 14,
             "MiscDropChanceID": 0,
             "MiscDropTypeID": 58
         },
-        "98": {
-            "MobDropID": 100,
+        "571": {
+            "MobDropID": 571,
             "CrateDropChanceID": 0,
-            "CrateDropTypeID": 24,
+            "CrateDropTypeID": 44,
+            "MiscDropChanceID": 0,
+            "MiscDropTypeID": 58
+        },
+        "572": {
+            "MobDropID": 572,
+            "CrateDropChanceID": 0,
+            "CrateDropTypeID": 70,
+            "MiscDropChanceID": 0,
+            "MiscDropTypeID": 58
+        },
+        "580": {
+            "MobDropID": 580,
+            "CrateDropChanceID": 0,
+            "CrateDropTypeID": 14,
             "MiscDropChanceID": 0,
             "MiscDropTypeID": 59
         },
-        "99": {
-            "MobDropID": 101,
+        "581": {
+            "MobDropID": 581,
             "CrateDropChanceID": 0,
-            "CrateDropTypeID": 25,
+            "CrateDropTypeID": 44,
+            "MiscDropChanceID": 0,
+            "MiscDropTypeID": 59
+        },
+        "582": {
+            "MobDropID": 582,
+            "CrateDropChanceID": 0,
+            "CrateDropTypeID": 70,
+            "MiscDropChanceID": 0,
+            "MiscDropTypeID": 59
+        },
+        "590": {
+            "MobDropID": 590,
+            "CrateDropChanceID": 0,
+            "CrateDropTypeID": 14,
             "MiscDropChanceID": 0,
             "MiscDropTypeID": 60
         },
-        "100": {
-            "MobDropID": 102,
+        "591": {
+            "MobDropID": 591,
             "CrateDropChanceID": 0,
-            "CrateDropTypeID": 25,
+            "CrateDropTypeID": 44,
             "MiscDropChanceID": 0,
             "MiscDropTypeID": 60
         },
-        "101": {
-            "MobDropID": 103,
+        "600": {
+            "MobDropID": 600,
             "CrateDropChanceID": 0,
-            "CrateDropTypeID": 25,
+            "CrateDropTypeID": 15,
             "MiscDropChanceID": 0,
             "MiscDropTypeID": 61
         },
-        "102": {
-            "MobDropID": 104,
+        "601": {
+            "MobDropID": 601,
             "CrateDropChanceID": 0,
-            "CrateDropTypeID": 25,
+            "CrateDropTypeID": 71,
             "MiscDropChanceID": 0,
-            "MiscDropTypeID": 60
+            "MiscDropTypeID": 61
         },
-        "103": {
-            "MobDropID": 105,
+        "610": {
+            "MobDropID": 610,
             "CrateDropChanceID": 0,
-            "CrateDropTypeID": 26,
-            "MiscDropChanceID": 0,
-            "MiscDropTypeID": 62
-        },
-        "104": {
-            "MobDropID": 106,
-            "CrateDropChanceID": 0,
-            "CrateDropTypeID": 26,
+            "CrateDropTypeID": 45,
             "MiscDropChanceID": 0,
             "MiscDropTypeID": 62
         },
-        "105": {
-            "MobDropID": 107,
+        "620": {
+            "MobDropID": 620,
             "CrateDropChanceID": 0,
-            "CrateDropTypeID": 26,
-            "MiscDropChanceID": 0,
-            "MiscDropTypeID": 62
-        },
-        "106": {
-            "MobDropID": 108,
-            "CrateDropChanceID": 0,
-            "CrateDropTypeID": 26,
-            "MiscDropChanceID": 0,
-            "MiscDropTypeID": 62
-        },
-        "107": {
-            "MobDropID": 109,
-            "CrateDropChanceID": 0,
-            "CrateDropTypeID": 27,
+            "CrateDropTypeID": 15,
             "MiscDropChanceID": 0,
             "MiscDropTypeID": 63
         },
-        "108": {
-            "MobDropID": 110,
+        "621": {
+            "MobDropID": 621,
             "CrateDropChanceID": 0,
-            "CrateDropTypeID": 27,
+            "CrateDropTypeID": 45,
             "MiscDropChanceID": 0,
             "MiscDropTypeID": 63
         },
-        "109": {
-            "MobDropID": 111,
+        "622": {
+            "MobDropID": 622,
             "CrateDropChanceID": 0,
-            "CrateDropTypeID": 27,
+            "CrateDropTypeID": 71,
+            "MiscDropChanceID": 0,
+            "MiscDropTypeID": 63
+        },
+        "630": {
+            "MobDropID": 630,
+            "CrateDropChanceID": 0,
+            "CrateDropTypeID": 15,
             "MiscDropChanceID": 0,
             "MiscDropTypeID": 64
         },
-        "110": {
-            "MobDropID": 112,
+        "631": {
+            "MobDropID": 631,
             "CrateDropChanceID": 0,
-            "CrateDropTypeID": 27,
+            "CrateDropTypeID": 45,
+            "MiscDropChanceID": 0,
+            "MiscDropTypeID": 64
+        },
+        "632": {
+            "MobDropID": 632,
+            "CrateDropChanceID": 0,
+            "CrateDropTypeID": 71,
+            "MiscDropChanceID": 0,
+            "MiscDropTypeID": 64
+        },
+        "640": {
+            "MobDropID": 640,
+            "CrateDropChanceID": 0,
+            "CrateDropTypeID": 16,
             "MiscDropChanceID": 0,
             "MiscDropTypeID": 65
         },
-        "111": {
-            "MobDropID": 113,
+        "641": {
+            "MobDropID": 641,
             "CrateDropChanceID": 0,
-            "CrateDropTypeID": 28,
+            "CrateDropTypeID": 46,
+            "MiscDropChanceID": 0,
+            "MiscDropTypeID": 65
+        },
+        "642": {
+            "MobDropID": 642,
+            "CrateDropChanceID": 0,
+            "CrateDropTypeID": 72,
+            "MiscDropChanceID": 0,
+            "MiscDropTypeID": 65
+        },
+        "650": {
+            "MobDropID": 650,
+            "CrateDropChanceID": 0,
+            "CrateDropTypeID": 16,
             "MiscDropChanceID": 0,
             "MiscDropTypeID": 66
         },
-        "112": {
-            "MobDropID": 114,
+        "651": {
+            "MobDropID": 651,
             "CrateDropChanceID": 0,
-            "CrateDropTypeID": 28,
+            "CrateDropTypeID": 46,
             "MiscDropChanceID": 0,
             "MiscDropTypeID": 66
         },
-        "113": {
-            "MobDropID": 115,
+        "652": {
+            "MobDropID": 652,
             "CrateDropChanceID": 0,
-            "CrateDropTypeID": 28,
+            "CrateDropTypeID": 72,
+            "MiscDropChanceID": 0,
+            "MiscDropTypeID": 66
+        },
+        "660": {
+            "MobDropID": 660,
+            "CrateDropChanceID": 0,
+            "CrateDropTypeID": 16,
             "MiscDropChanceID": 0,
             "MiscDropTypeID": 67
         },
-        "114": {
-            "MobDropID": 116,
+        "661": {
+            "MobDropID": 661,
             "CrateDropChanceID": 0,
-            "CrateDropTypeID": 28,
+            "CrateDropTypeID": 46,
             "MiscDropChanceID": 0,
-            "MiscDropTypeID": 66
+            "MiscDropTypeID": 67
         },
-        "115": {
-            "MobDropID": 117,
+        "662": {
+            "MobDropID": 662,
             "CrateDropChanceID": 0,
-            "CrateDropTypeID": 29,
+            "CrateDropTypeID": 72,
+            "MiscDropChanceID": 0,
+            "MiscDropTypeID": 67
+        },
+        "670": {
+            "MobDropID": 670,
+            "CrateDropChanceID": 0,
+            "CrateDropTypeID": 46,
             "MiscDropChanceID": 0,
             "MiscDropTypeID": 68
         },
-        "116": {
-            "MobDropID": 118,
+        "671": {
+            "MobDropID": 671,
             "CrateDropChanceID": 0,
-            "CrateDropTypeID": 29,
+            "CrateDropTypeID": 72,
             "MiscDropChanceID": 0,
             "MiscDropTypeID": 68
         },
-        "117": {
-            "MobDropID": 119,
+        "680": {
+            "MobDropID": 680,
             "CrateDropChanceID": 0,
-            "CrateDropTypeID": 29,
+            "CrateDropTypeID": 17,
             "MiscDropChanceID": 0,
             "MiscDropTypeID": 69
         },
-        "118": {
-            "MobDropID": 120,
+        "681": {
+            "MobDropID": 681,
             "CrateDropChanceID": 0,
-            "CrateDropTypeID": 29,
+            "CrateDropTypeID": 73,
             "MiscDropChanceID": 0,
-            "MiscDropTypeID": 68
+            "MiscDropTypeID": 69
         },
-        "119": {
-            "MobDropID": 121,
+        "690": {
+            "MobDropID": 690,
             "CrateDropChanceID": 0,
-            "CrateDropTypeID": 30,
-            "MiscDropChanceID": 0,
-            "MiscDropTypeID": 70
-        },
-        "120": {
-            "MobDropID": 122,
-            "CrateDropChanceID": 0,
-            "CrateDropTypeID": 30,
+            "CrateDropTypeID": 17,
             "MiscDropChanceID": 0,
             "MiscDropTypeID": 70
         },
-        "121": {
-            "MobDropID": 123,
+        "691": {
+            "MobDropID": 691,
             "CrateDropChanceID": 0,
-            "CrateDropTypeID": 30,
+            "CrateDropTypeID": 47,
+            "MiscDropChanceID": 0,
+            "MiscDropTypeID": 70
+        },
+        "692": {
+            "MobDropID": 692,
+            "CrateDropChanceID": 0,
+            "CrateDropTypeID": 73,
+            "MiscDropChanceID": 0,
+            "MiscDropTypeID": 70
+        },
+        "700": {
+            "MobDropID": 700,
+            "CrateDropChanceID": 0,
+            "CrateDropTypeID": 17,
             "MiscDropChanceID": 0,
             "MiscDropTypeID": 71
         },
-        "122": {
-            "MobDropID": 124,
+        "701": {
+            "MobDropID": 701,
             "CrateDropChanceID": 0,
-            "CrateDropTypeID": 30,
+            "CrateDropTypeID": 47,
+            "MiscDropChanceID": 0,
+            "MiscDropTypeID": 71
+        },
+        "702": {
+            "MobDropID": 702,
+            "CrateDropChanceID": 0,
+            "CrateDropTypeID": 73,
+            "MiscDropChanceID": 0,
+            "MiscDropTypeID": 71
+        },
+        "710": {
+            "MobDropID": 710,
+            "CrateDropChanceID": 0,
+            "CrateDropTypeID": 47,
             "MiscDropChanceID": 0,
             "MiscDropTypeID": 72
         },
-        "123": {
-            "MobDropID": 125,
+        "720": {
+            "MobDropID": 720,
             "CrateDropChanceID": 0,
-            "CrateDropTypeID": 31,
+            "CrateDropTypeID": 18,
             "MiscDropChanceID": 0,
             "MiscDropTypeID": 73
         },
-        "124": {
-            "MobDropID": 126,
+        "721": {
+            "MobDropID": 721,
             "CrateDropChanceID": 0,
-            "CrateDropTypeID": 31,
+            "CrateDropTypeID": 48,
             "MiscDropChanceID": 0,
             "MiscDropTypeID": 73
         },
-        "125": {
-            "MobDropID": 127,
+        "722": {
+            "MobDropID": 722,
             "CrateDropChanceID": 0,
-            "CrateDropTypeID": 31,
+            "CrateDropTypeID": 74,
+            "MiscDropChanceID": 0,
+            "MiscDropTypeID": 73
+        },
+        "730": {
+            "MobDropID": 730,
+            "CrateDropChanceID": 0,
+            "CrateDropTypeID": 18,
             "MiscDropChanceID": 0,
             "MiscDropTypeID": 74
         },
-        "126": {
-            "MobDropID": 128,
+        "731": {
+            "MobDropID": 731,
             "CrateDropChanceID": 0,
-            "CrateDropTypeID": 31,
+            "CrateDropTypeID": 48,
             "MiscDropChanceID": 0,
-            "MiscDropTypeID": 73
+            "MiscDropTypeID": 74
         },
-        "127": {
-            "MobDropID": 129,
+        "732": {
+            "MobDropID": 732,
             "CrateDropChanceID": 0,
-            "CrateDropTypeID": 32,
+            "CrateDropTypeID": 74,
+            "MiscDropChanceID": 0,
+            "MiscDropTypeID": 74
+        },
+        "740": {
+            "MobDropID": 740,
+            "CrateDropChanceID": 0,
+            "CrateDropTypeID": 18,
             "MiscDropChanceID": 0,
             "MiscDropTypeID": 75
         },
-        "128": {
-            "MobDropID": 130,
+        "741": {
+            "MobDropID": 741,
             "CrateDropChanceID": 0,
-            "CrateDropTypeID": 32,
+            "CrateDropTypeID": 48,
             "MiscDropChanceID": 0,
             "MiscDropTypeID": 75
         },
-        "129": {
-            "MobDropID": 131,
+        "742": {
+            "MobDropID": 742,
             "CrateDropChanceID": 0,
-            "CrateDropTypeID": 32,
+            "CrateDropTypeID": 74,
+            "MiscDropChanceID": 0,
+            "MiscDropTypeID": 75
+        },
+        "750": {
+            "MobDropID": 750,
+            "CrateDropChanceID": 0,
+            "CrateDropTypeID": 18,
             "MiscDropChanceID": 0,
             "MiscDropTypeID": 76
         },
-        "130": {
-            "MobDropID": 132,
+        "751": {
+            "MobDropID": 751,
             "CrateDropChanceID": 0,
-            "CrateDropTypeID": 32,
+            "CrateDropTypeID": 48,
             "MiscDropChanceID": 0,
-            "MiscDropTypeID": 75
+            "MiscDropTypeID": 76
         },
-        "131": {
-            "MobDropID": 133,
+        "760": {
+            "MobDropID": 760,
             "CrateDropChanceID": 0,
-            "CrateDropTypeID": 33,
+            "CrateDropTypeID": 19,
             "MiscDropChanceID": 0,
             "MiscDropTypeID": 77
         },
-        "132": {
-            "MobDropID": 134,
+        "761": {
+            "MobDropID": 761,
             "CrateDropChanceID": 0,
-            "CrateDropTypeID": 33,
+            "CrateDropTypeID": 49,
+            "MiscDropChanceID": 0,
+            "MiscDropTypeID": 77
+        },
+        "762": {
+            "MobDropID": 762,
+            "CrateDropChanceID": 0,
+            "CrateDropTypeID": 75,
+            "MiscDropChanceID": 0,
+            "MiscDropTypeID": 77
+        },
+        "770": {
+            "MobDropID": 770,
+            "CrateDropChanceID": 0,
+            "CrateDropTypeID": 19,
             "MiscDropChanceID": 0,
             "MiscDropTypeID": 78
         },
-        "133": {
-            "MobDropID": 135,
+        "771": {
+            "MobDropID": 771,
             "CrateDropChanceID": 0,
-            "CrateDropTypeID": 33,
+            "CrateDropTypeID": 49,
+            "MiscDropChanceID": 0,
+            "MiscDropTypeID": 78
+        },
+        "772": {
+            "MobDropID": 772,
+            "CrateDropChanceID": 0,
+            "CrateDropTypeID": 75,
+            "MiscDropChanceID": 0,
+            "MiscDropTypeID": 78
+        },
+        "780": {
+            "MobDropID": 780,
+            "CrateDropChanceID": 0,
+            "CrateDropTypeID": 19,
             "MiscDropChanceID": 0,
             "MiscDropTypeID": 79
         },
-        "134": {
-            "MobDropID": 136,
+        "781": {
+            "MobDropID": 781,
             "CrateDropChanceID": 0,
-            "CrateDropTypeID": 33,
+            "CrateDropTypeID": 49,
             "MiscDropChanceID": 0,
-            "MiscDropTypeID": 78
+            "MiscDropTypeID": 79
         },
-        "135": {
-            "MobDropID": 137,
+        "782": {
+            "MobDropID": 782,
             "CrateDropChanceID": 0,
-            "CrateDropTypeID": 34,
+            "CrateDropTypeID": 75,
+            "MiscDropChanceID": 0,
+            "MiscDropTypeID": 79
+        },
+        "790": {
+            "MobDropID": 790,
+            "CrateDropChanceID": 0,
+            "CrateDropTypeID": 19,
             "MiscDropChanceID": 0,
             "MiscDropTypeID": 80
         },
-        "136": {
-            "MobDropID": 138,
+        "791": {
+            "MobDropID": 791,
             "CrateDropChanceID": 0,
-            "CrateDropTypeID": 34,
+            "CrateDropTypeID": 49,
             "MiscDropChanceID": 0,
             "MiscDropTypeID": 80
         },
-        "137": {
-            "MobDropID": 139,
+        "800": {
+            "MobDropID": 800,
             "CrateDropChanceID": 0,
-            "CrateDropTypeID": 34,
+            "CrateDropTypeID": 20,
             "MiscDropChanceID": 0,
             "MiscDropTypeID": 81
         },
-        "138": {
-            "MobDropID": 140,
+        "801": {
+            "MobDropID": 801,
             "CrateDropChanceID": 0,
-            "CrateDropTypeID": 34,
+            "CrateDropTypeID": 50,
             "MiscDropChanceID": 0,
-            "MiscDropTypeID": 80
+            "MiscDropTypeID": 81
         },
-        "139": {
-            "MobDropID": 141,
+        "802": {
+            "MobDropID": 802,
             "CrateDropChanceID": 0,
-            "CrateDropTypeID": 35,
+            "CrateDropTypeID": 77,
+            "MiscDropChanceID": 0,
+            "MiscDropTypeID": 81
+        },
+        "810": {
+            "MobDropID": 810,
+            "CrateDropChanceID": 0,
+            "CrateDropTypeID": 20,
             "MiscDropChanceID": 0,
             "MiscDropTypeID": 82
         },
-        "140": {
-            "MobDropID": 142,
+        "811": {
+            "MobDropID": 811,
             "CrateDropChanceID": 0,
-            "CrateDropTypeID": 35,
+            "CrateDropTypeID": 50,
             "MiscDropChanceID": 0,
             "MiscDropTypeID": 82
         },
-        "141": {
-            "MobDropID": 143,
+        "812": {
+            "MobDropID": 812,
             "CrateDropChanceID": 0,
-            "CrateDropTypeID": 35,
+            "CrateDropTypeID": 77,
+            "MiscDropChanceID": 0,
+            "MiscDropTypeID": 82
+        },
+        "820": {
+            "MobDropID": 820,
+            "CrateDropChanceID": 0,
+            "CrateDropTypeID": 20,
             "MiscDropChanceID": 0,
             "MiscDropTypeID": 83
         },
-        "142": {
-            "MobDropID": 178,
+        "821": {
+            "MobDropID": 821,
             "CrateDropChanceID": 0,
-            "CrateDropTypeID": 36,
+            "CrateDropTypeID": 50,
             "MiscDropChanceID": 0,
-            "MiscDropTypeID": 19
+            "MiscDropTypeID": 83
         },
-        "143": {
-            "MobDropID": 179,
+        "822": {
+            "MobDropID": 822,
             "CrateDropChanceID": 0,
-            "CrateDropTypeID": 36,
+            "CrateDropTypeID": 77,
             "MiscDropChanceID": 0,
-            "MiscDropTypeID": 19
+            "MiscDropTypeID": 83
         },
-        "144": {
-            "MobDropID": 180,
+        "830": {
+            "MobDropID": 830,
             "CrateDropChanceID": 0,
-            "CrateDropTypeID": 36,
-            "MiscDropChanceID": 0,
-            "MiscDropTypeID": 20
-        },
-        "145": {
-            "MobDropID": 182,
-            "CrateDropChanceID": 0,
-            "CrateDropTypeID": 37,
-            "MiscDropChanceID": 0,
-            "MiscDropTypeID": 21
-        },
-        "146": {
-            "MobDropID": 183,
-            "CrateDropChanceID": 0,
-            "CrateDropTypeID": 37,
-            "MiscDropChanceID": 0,
-            "MiscDropTypeID": 21
-        },
-        "147": {
-            "MobDropID": 184,
-            "CrateDropChanceID": 0,
-            "CrateDropTypeID": 37,
+            "CrateDropTypeID": 20,
             "MiscDropChanceID": 0,
             "MiscDropTypeID": 84
         },
-        "148": {
-            "MobDropID": 185,
+        "831": {
+            "MobDropID": 831,
             "CrateDropChanceID": 0,
-            "CrateDropTypeID": 37,
+            "CrateDropTypeID": 50,
             "MiscDropChanceID": 0,
-            "MiscDropTypeID": 21
+            "MiscDropTypeID": 84
         },
-        "149": {
-            "MobDropID": 186,
+        "832": {
+            "MobDropID": 832,
             "CrateDropChanceID": 0,
-            "CrateDropTypeID": 38,
+            "CrateDropTypeID": 77,
+            "MiscDropChanceID": 0,
+            "MiscDropTypeID": 84
+        },
+        "840": {
+            "MobDropID": 840,
+            "CrateDropChanceID": 0,
+            "CrateDropTypeID": 21,
             "MiscDropChanceID": 0,
             "MiscDropTypeID": 85
         },
-        "150": {
-            "MobDropID": 187,
+        "841": {
+            "MobDropID": 841,
             "CrateDropChanceID": 0,
-            "CrateDropTypeID": 38,
+            "CrateDropTypeID": 51,
             "MiscDropChanceID": 0,
             "MiscDropTypeID": 85
         },
-        "151": {
-            "MobDropID": 188,
+        "842": {
+            "MobDropID": 842,
             "CrateDropChanceID": 0,
-            "CrateDropTypeID": 38,
+            "CrateDropTypeID": 78,
+            "MiscDropChanceID": 0,
+            "MiscDropTypeID": 85
+        },
+        "850": {
+            "MobDropID": 850,
+            "CrateDropChanceID": 0,
+            "CrateDropTypeID": 21,
             "MiscDropChanceID": 0,
             "MiscDropTypeID": 86
         },
-        "152": {
-            "MobDropID": 189,
+        "851": {
+            "MobDropID": 851,
             "CrateDropChanceID": 0,
-            "CrateDropTypeID": 38,
+            "CrateDropTypeID": 51,
             "MiscDropChanceID": 0,
-            "MiscDropTypeID": 22
+            "MiscDropTypeID": 86
         },
-        "153": {
-            "MobDropID": 190,
+        "852": {
+            "MobDropID": 852,
             "CrateDropChanceID": 0,
-            "CrateDropTypeID": 39,
+            "CrateDropTypeID": 78,
             "MiscDropChanceID": 0,
-            "MiscDropTypeID": 25
+            "MiscDropTypeID": 86
         },
-        "154": {
-            "MobDropID": 191,
+        "860": {
+            "MobDropID": 860,
             "CrateDropChanceID": 0,
-            "CrateDropTypeID": 39,
-            "MiscDropChanceID": 0,
-            "MiscDropTypeID": 25
-        },
-        "155": {
-            "MobDropID": 192,
-            "CrateDropChanceID": 0,
-            "CrateDropTypeID": 39,
+            "CrateDropTypeID": 21,
             "MiscDropChanceID": 0,
             "MiscDropTypeID": 87
         },
-        "156": {
-            "MobDropID": 193,
+        "861": {
+            "MobDropID": 861,
             "CrateDropChanceID": 0,
-            "CrateDropTypeID": 39,
+            "CrateDropTypeID": 51,
+            "MiscDropChanceID": 0,
+            "MiscDropTypeID": 87
+        },
+        "862": {
+            "MobDropID": 862,
+            "CrateDropChanceID": 0,
+            "CrateDropTypeID": 78,
+            "MiscDropChanceID": 0,
+            "MiscDropTypeID": 87
+        },
+        "870": {
+            "MobDropID": 870,
+            "CrateDropChanceID": 0,
+            "CrateDropTypeID": 21,
             "MiscDropChanceID": 0,
             "MiscDropTypeID": 88
         },
-        "157": {
-            "MobDropID": 194,
+        "871": {
+            "MobDropID": 871,
             "CrateDropChanceID": 0,
-            "CrateDropTypeID": 40,
+            "CrateDropTypeID": 51,
             "MiscDropChanceID": 0,
-            "MiscDropTypeID": 29
+            "MiscDropTypeID": 88
         },
-        "158": {
-            "MobDropID": 195,
+        "872": {
+            "MobDropID": 872,
             "CrateDropChanceID": 0,
-            "CrateDropTypeID": 40,
+            "CrateDropTypeID": 78,
             "MiscDropChanceID": 0,
-            "MiscDropTypeID": 29
+            "MiscDropTypeID": 88
         },
-        "159": {
-            "MobDropID": 196,
+        "880": {
+            "MobDropID": 880,
             "CrateDropChanceID": 0,
-            "CrateDropTypeID": 40,
-            "MiscDropChanceID": 0,
-            "MiscDropTypeID": 30
-        },
-        "160": {
-            "MobDropID": 197,
-            "CrateDropChanceID": 0,
-            "CrateDropTypeID": 40,
-            "MiscDropChanceID": 0,
-            "MiscDropTypeID": 27
-        },
-        "161": {
-            "MobDropID": 198,
-            "CrateDropChanceID": 0,
-            "CrateDropTypeID": 41,
-            "MiscDropChanceID": 0,
-            "MiscDropTypeID": 31
-        },
-        "162": {
-            "MobDropID": 199,
-            "CrateDropChanceID": 0,
-            "CrateDropTypeID": 41,
-            "MiscDropChanceID": 0,
-            "MiscDropTypeID": 31
-        },
-        "163": {
-            "MobDropID": 200,
-            "CrateDropChanceID": 0,
-            "CrateDropTypeID": 41,
-            "MiscDropChanceID": 0,
-            "MiscDropTypeID": 30
-        },
-        "164": {
-            "MobDropID": 201,
-            "CrateDropChanceID": 0,
-            "CrateDropTypeID": 41,
-            "MiscDropChanceID": 0,
-            "MiscDropTypeID": 31
-        },
-        "165": {
-            "MobDropID": 202,
-            "CrateDropChanceID": 0,
-            "CrateDropTypeID": 42,
-            "MiscDropChanceID": 0,
-            "MiscDropTypeID": 34
-        },
-        "166": {
-            "MobDropID": 203,
-            "CrateDropChanceID": 0,
-            "CrateDropTypeID": 42,
-            "MiscDropChanceID": 0,
-            "MiscDropTypeID": 34
-        },
-        "167": {
-            "MobDropID": 204,
-            "CrateDropChanceID": 0,
-            "CrateDropTypeID": 42,
-            "MiscDropChanceID": 0,
-            "MiscDropTypeID": 33
-        },
-        "168": {
-            "MobDropID": 205,
-            "CrateDropChanceID": 0,
-            "CrateDropTypeID": 42,
-            "MiscDropChanceID": 0,
-            "MiscDropTypeID": 34
-        },
-        "169": {
-            "MobDropID": 206,
-            "CrateDropChanceID": 0,
-            "CrateDropTypeID": 43,
-            "MiscDropChanceID": 0,
-            "MiscDropTypeID": 32
-        },
-        "170": {
-            "MobDropID": 207,
-            "CrateDropChanceID": 0,
-            "CrateDropTypeID": 43,
-            "MiscDropChanceID": 0,
-            "MiscDropTypeID": 32
-        },
-        "171": {
-            "MobDropID": 208,
-            "CrateDropChanceID": 0,
-            "CrateDropTypeID": 43,
-            "MiscDropChanceID": 0,
-            "MiscDropTypeID": 33
-        },
-        "172": {
-            "MobDropID": 209,
-            "CrateDropChanceID": 0,
-            "CrateDropTypeID": 43,
-            "MiscDropChanceID": 0,
-            "MiscDropTypeID": 35
-        },
-        "173": {
-            "MobDropID": 210,
-            "CrateDropChanceID": 0,
-            "CrateDropTypeID": 44,
-            "MiscDropChanceID": 0,
-            "MiscDropTypeID": 36
-        },
-        "174": {
-            "MobDropID": 211,
-            "CrateDropChanceID": 0,
-            "CrateDropTypeID": 44,
-            "MiscDropChanceID": 0,
-            "MiscDropTypeID": 36
-        },
-        "175": {
-            "MobDropID": 212,
-            "CrateDropChanceID": 0,
-            "CrateDropTypeID": 44,
-            "MiscDropChanceID": 0,
-            "MiscDropTypeID": 37
-        },
-        "176": {
-            "MobDropID": 213,
-            "CrateDropChanceID": 0,
-            "CrateDropTypeID": 44,
-            "MiscDropChanceID": 0,
-            "MiscDropTypeID": 38
-        },
-        "177": {
-            "MobDropID": 214,
-            "CrateDropChanceID": 0,
-            "CrateDropTypeID": 45,
+            "CrateDropTypeID": 22,
             "MiscDropChanceID": 0,
             "MiscDropTypeID": 89
         },
-        "178": {
-            "MobDropID": 215,
+        "881": {
+            "MobDropID": 881,
             "CrateDropChanceID": 0,
-            "CrateDropTypeID": 45,
+            "CrateDropTypeID": 52,
             "MiscDropChanceID": 0,
             "MiscDropTypeID": 89
         },
-        "179": {
-            "MobDropID": 216,
+        "882": {
+            "MobDropID": 882,
             "CrateDropChanceID": 0,
-            "CrateDropTypeID": 45,
+            "CrateDropTypeID": 79,
             "MiscDropChanceID": 0,
-            "MiscDropTypeID": 40
+            "MiscDropTypeID": 89
         },
-        "180": {
-            "MobDropID": 217,
+        "890": {
+            "MobDropID": 890,
             "CrateDropChanceID": 0,
-            "CrateDropTypeID": 45,
-            "MiscDropChanceID": 0,
-            "MiscDropTypeID": 39
-        },
-        "181": {
-            "MobDropID": 218,
-            "CrateDropChanceID": 0,
-            "CrateDropTypeID": 46,
+            "CrateDropTypeID": 22,
             "MiscDropChanceID": 0,
             "MiscDropTypeID": 90
         },
-        "182": {
-            "MobDropID": 219,
+        "891": {
+            "MobDropID": 891,
             "CrateDropChanceID": 0,
-            "CrateDropTypeID": 46,
+            "CrateDropTypeID": 52,
             "MiscDropChanceID": 0,
             "MiscDropTypeID": 90
         },
-        "183": {
-            "MobDropID": 220,
+        "892": {
+            "MobDropID": 892,
             "CrateDropChanceID": 0,
-            "CrateDropTypeID": 46,
+            "CrateDropTypeID": 79,
+            "MiscDropChanceID": 0,
+            "MiscDropTypeID": 90
+        },
+        "900": {
+            "MobDropID": 900,
+            "CrateDropChanceID": 0,
+            "CrateDropTypeID": 22,
             "MiscDropChanceID": 0,
             "MiscDropTypeID": 91
         },
-        "184": {
-            "MobDropID": 221,
+        "901": {
+            "MobDropID": 901,
             "CrateDropChanceID": 0,
-            "CrateDropTypeID": 46,
+            "CrateDropTypeID": 52,
             "MiscDropChanceID": 0,
-            "MiscDropTypeID": 41
+            "MiscDropTypeID": 91
         },
-        "185": {
-            "MobDropID": 222,
+        "902": {
+            "MobDropID": 902,
             "CrateDropChanceID": 0,
-            "CrateDropTypeID": 47,
+            "CrateDropTypeID": 79,
             "MiscDropChanceID": 0,
-            "MiscDropTypeID": 43
+            "MiscDropTypeID": 91
         },
-        "186": {
-            "MobDropID": 223,
+        "910": {
+            "MobDropID": 910,
             "CrateDropChanceID": 0,
-            "CrateDropTypeID": 47,
-            "MiscDropChanceID": 0,
-            "MiscDropTypeID": 43
-        },
-        "187": {
-            "MobDropID": 224,
-            "CrateDropChanceID": 0,
-            "CrateDropTypeID": 47,
+            "CrateDropTypeID": 22,
             "MiscDropChanceID": 0,
             "MiscDropTypeID": 92
         },
-        "188": {
-            "MobDropID": 225,
+        "911": {
+            "MobDropID": 911,
             "CrateDropChanceID": 0,
-            "CrateDropTypeID": 47,
+            "CrateDropTypeID": 52,
+            "MiscDropChanceID": 0,
+            "MiscDropTypeID": 92
+        },
+        "912": {
+            "MobDropID": 912,
+            "CrateDropChanceID": 0,
+            "CrateDropTypeID": 79,
+            "MiscDropChanceID": 0,
+            "MiscDropTypeID": 92
+        },
+        "920": {
+            "MobDropID": 920,
+            "CrateDropChanceID": 0,
+            "CrateDropTypeID": 23,
             "MiscDropChanceID": 0,
             "MiscDropTypeID": 93
         },
-        "189": {
-            "MobDropID": 226,
+        "921": {
+            "MobDropID": 921,
             "CrateDropChanceID": 0,
-            "CrateDropTypeID": 48,
+            "CrateDropTypeID": 53,
+            "MiscDropChanceID": 0,
+            "MiscDropTypeID": 93
+        },
+        "922": {
+            "MobDropID": 922,
+            "CrateDropChanceID": 0,
+            "CrateDropTypeID": 76,
+            "MiscDropChanceID": 0,
+            "MiscDropTypeID": 93
+        },
+        "930": {
+            "MobDropID": 930,
+            "CrateDropChanceID": 0,
+            "CrateDropTypeID": 23,
             "MiscDropChanceID": 0,
             "MiscDropTypeID": 94
         },
-        "190": {
-            "MobDropID": 227,
+        "931": {
+            "MobDropID": 931,
             "CrateDropChanceID": 0,
-            "CrateDropTypeID": 48,
+            "CrateDropTypeID": 53,
             "MiscDropChanceID": 0,
             "MiscDropTypeID": 94
         },
-        "191": {
-            "MobDropID": 228,
+        "940": {
+            "MobDropID": 940,
             "CrateDropChanceID": 0,
-            "CrateDropTypeID": 48,
+            "CrateDropTypeID": 23,
             "MiscDropChanceID": 0,
             "MiscDropTypeID": 95
         },
-        "192": {
-            "MobDropID": 229,
+        "941": {
+            "MobDropID": 941,
             "CrateDropChanceID": 0,
-            "CrateDropTypeID": 48,
+            "CrateDropTypeID": 53,
             "MiscDropChanceID": 0,
-            "MiscDropTypeID": 45
+            "MiscDropTypeID": 95
         },
-        "193": {
-            "MobDropID": 230,
+        "942": {
+            "MobDropID": 942,
             "CrateDropChanceID": 0,
-            "CrateDropTypeID": 49,
+            "CrateDropTypeID": 76,
+            "MiscDropChanceID": 0,
+            "MiscDropTypeID": 95
+        },
+        "950": {
+            "MobDropID": 950,
+            "CrateDropChanceID": 0,
+            "CrateDropTypeID": 23,
             "MiscDropChanceID": 0,
             "MiscDropTypeID": 96
         },
-        "194": {
-            "MobDropID": 231,
+        "951": {
+            "MobDropID": 951,
             "CrateDropChanceID": 0,
-            "CrateDropTypeID": 49,
+            "CrateDropTypeID": 76,
             "MiscDropChanceID": 0,
             "MiscDropTypeID": 96
         },
-        "195": {
-            "MobDropID": 232,
+        "960": {
+            "MobDropID": 960,
             "CrateDropChanceID": 0,
-            "CrateDropTypeID": 49,
-            "MiscDropChanceID": 0,
-            "MiscDropTypeID": 48
-        },
-        "196": {
-            "MobDropID": 233,
-            "CrateDropChanceID": 0,
-            "CrateDropTypeID": 49,
-            "MiscDropChanceID": 0,
-            "MiscDropTypeID": 47
-        },
-        "197": {
-            "MobDropID": 234,
-            "CrateDropChanceID": 0,
-            "CrateDropTypeID": 50,
+            "CrateDropTypeID": 24,
             "MiscDropChanceID": 0,
             "MiscDropTypeID": 97
         },
-        "198": {
-            "MobDropID": 235,
+        "961": {
+            "MobDropID": 961,
             "CrateDropChanceID": 0,
-            "CrateDropTypeID": 50,
+            "CrateDropTypeID": 54,
             "MiscDropChanceID": 0,
             "MiscDropTypeID": 97
         },
-        "199": {
-            "MobDropID": 236,
+        "962": {
+            "MobDropID": 962,
             "CrateDropChanceID": 0,
-            "CrateDropTypeID": 50,
+            "CrateDropTypeID": 80,
+            "MiscDropChanceID": 0,
+            "MiscDropTypeID": 97
+        },
+        "970": {
+            "MobDropID": 970,
+            "CrateDropChanceID": 0,
+            "CrateDropTypeID": 24,
             "MiscDropChanceID": 0,
             "MiscDropTypeID": 98
         },
-        "200": {
-            "MobDropID": 237,
+        "971": {
+            "MobDropID": 971,
             "CrateDropChanceID": 0,
-            "CrateDropTypeID": 50,
+            "CrateDropTypeID": 80,
             "MiscDropChanceID": 0,
-            "MiscDropTypeID": 49
+            "MiscDropTypeID": 98
         },
-        "201": {
-            "MobDropID": 238,
+        "980": {
+            "MobDropID": 980,
             "CrateDropChanceID": 0,
-            "CrateDropTypeID": 51,
-            "MiscDropChanceID": 0,
-            "MiscDropTypeID": 99
-        },
-        "202": {
-            "MobDropID": 239,
-            "CrateDropChanceID": 0,
-            "CrateDropTypeID": 51,
+            "CrateDropTypeID": 24,
             "MiscDropChanceID": 0,
             "MiscDropTypeID": 99
         },
-        "203": {
-            "MobDropID": 240,
+        "981": {
+            "MobDropID": 981,
             "CrateDropChanceID": 0,
-            "CrateDropTypeID": 51,
+            "CrateDropTypeID": 54,
             "MiscDropChanceID": 0,
-            "MiscDropTypeID": 52
+            "MiscDropTypeID": 99
         },
-        "204": {
-            "MobDropID": 241,
+        "982": {
+            "MobDropID": 982,
             "CrateDropChanceID": 0,
-            "CrateDropTypeID": 51,
+            "CrateDropTypeID": 80,
             "MiscDropChanceID": 0,
-            "MiscDropTypeID": 51
+            "MiscDropTypeID": 99
         },
-        "205": {
-            "MobDropID": 242,
+        "990": {
+            "MobDropID": 990,
             "CrateDropChanceID": 0,
-            "CrateDropTypeID": 52,
+            "CrateDropTypeID": 24,
             "MiscDropChanceID": 0,
             "MiscDropTypeID": 100
         },
-        "206": {
-            "MobDropID": 243,
+        "991": {
+            "MobDropID": 991,
             "CrateDropChanceID": 0,
-            "CrateDropTypeID": 52,
+            "CrateDropTypeID": 54,
             "MiscDropChanceID": 0,
             "MiscDropTypeID": 100
         },
-        "207": {
-            "MobDropID": 244,
+        "992": {
+            "MobDropID": 992,
             "CrateDropChanceID": 0,
-            "CrateDropTypeID": 52,
+            "CrateDropTypeID": 80,
             "MiscDropChanceID": 0,
-            "MiscDropTypeID": 54
+            "MiscDropTypeID": 100
         },
-        "208": {
-            "MobDropID": 245,
+        "1000": {
+            "MobDropID": 1000,
             "CrateDropChanceID": 0,
-            "CrateDropTypeID": 52,
-            "MiscDropChanceID": 0,
-            "MiscDropTypeID": 53
-        },
-        "209": {
-            "MobDropID": 246,
-            "CrateDropChanceID": 0,
-            "CrateDropTypeID": 53,
+            "CrateDropTypeID": 25,
             "MiscDropChanceID": 0,
             "MiscDropTypeID": 101
         },
-        "210": {
-            "MobDropID": 247,
+        "1001": {
+            "MobDropID": 1001,
             "CrateDropChanceID": 0,
-            "CrateDropTypeID": 53,
+            "CrateDropTypeID": 55,
             "MiscDropChanceID": 0,
             "MiscDropTypeID": 101
         },
-        "211": {
-            "MobDropID": 248,
+        "1010": {
+            "MobDropID": 1010,
             "CrateDropChanceID": 0,
-            "CrateDropTypeID": 53,
-            "MiscDropChanceID": 0,
-            "MiscDropTypeID": 56
-        },
-        "212": {
-            "MobDropID": 249,
-            "CrateDropChanceID": 0,
-            "CrateDropTypeID": 53,
-            "MiscDropChanceID": 0,
-            "MiscDropTypeID": 55
-        },
-        "213": {
-            "MobDropID": 250,
-            "CrateDropChanceID": 0,
-            "CrateDropTypeID": 54,
-            "MiscDropChanceID": 0,
-            "MiscDropTypeID": 57
-        },
-        "214": {
-            "MobDropID": 251,
-            "CrateDropChanceID": 0,
-            "CrateDropTypeID": 54,
-            "MiscDropChanceID": 0,
-            "MiscDropTypeID": 57
-        },
-        "215": {
-            "MobDropID": 252,
-            "CrateDropChanceID": 0,
-            "CrateDropTypeID": 54,
-            "MiscDropChanceID": 0,
-            "MiscDropTypeID": 58
-        },
-        "216": {
-            "MobDropID": 253,
-            "CrateDropChanceID": 0,
-            "CrateDropTypeID": 54,
-            "MiscDropChanceID": 0,
-            "MiscDropTypeID": 59
-        },
-        "217": {
-            "MobDropID": 254,
-            "CrateDropChanceID": 0,
-            "CrateDropTypeID": 55,
+            "CrateDropTypeID": 25,
             "MiscDropChanceID": 0,
             "MiscDropTypeID": 102
         },
-        "218": {
-            "MobDropID": 255,
+        "1011": {
+            "MobDropID": 1011,
             "CrateDropChanceID": 0,
-            "CrateDropTypeID": 55,
+            "CrateDropTypeID": 81,
             "MiscDropChanceID": 0,
             "MiscDropTypeID": 102
         },
-        "219": {
-            "MobDropID": 256,
+        "1020": {
+            "MobDropID": 1020,
             "CrateDropChanceID": 0,
-            "CrateDropTypeID": 55,
-            "MiscDropChanceID": 0,
-            "MiscDropTypeID": 61
-        },
-        "220": {
-            "MobDropID": 257,
-            "CrateDropChanceID": 0,
-            "CrateDropTypeID": 55,
-            "MiscDropChanceID": 0,
-            "MiscDropTypeID": 60
-        },
-        "221": {
-            "MobDropID": 258,
-            "CrateDropChanceID": 0,
-            "CrateDropTypeID": 56,
-            "MiscDropChanceID": 0,
-            "MiscDropTypeID": 62
-        },
-        "222": {
-            "MobDropID": 259,
-            "CrateDropChanceID": 0,
-            "CrateDropTypeID": 56,
-            "MiscDropChanceID": 0,
-            "MiscDropTypeID": 62
-        },
-        "223": {
-            "MobDropID": 260,
-            "CrateDropChanceID": 0,
-            "CrateDropTypeID": 56,
+            "CrateDropTypeID": 25,
             "MiscDropChanceID": 0,
             "MiscDropTypeID": 103
         },
-        "224": {
-            "MobDropID": 261,
+        "1021": {
+            "MobDropID": 1021,
             "CrateDropChanceID": 0,
-            "CrateDropTypeID": 56,
+            "CrateDropTypeID": 55,
             "MiscDropChanceID": 0,
-            "MiscDropTypeID": 62
+            "MiscDropTypeID": 103
         },
-        "225": {
-            "MobDropID": 262,
+        "1022": {
+            "MobDropID": 1022,
             "CrateDropChanceID": 0,
-            "CrateDropTypeID": 57,
+            "CrateDropTypeID": 81,
             "MiscDropChanceID": 0,
-            "MiscDropTypeID": 63
+            "MiscDropTypeID": 103
         },
-        "226": {
-            "MobDropID": 263,
+        "1030": {
+            "MobDropID": 1030,
             "CrateDropChanceID": 0,
-            "CrateDropTypeID": 57,
-            "MiscDropChanceID": 0,
-            "MiscDropTypeID": 63
-        },
-        "227": {
-            "MobDropID": 264,
-            "CrateDropChanceID": 0,
-            "CrateDropTypeID": 57,
+            "CrateDropTypeID": 25,
             "MiscDropChanceID": 0,
             "MiscDropTypeID": 104
         },
-        "228": {
-            "MobDropID": 266,
+        "1031": {
+            "MobDropID": 1031,
             "CrateDropChanceID": 0,
-            "CrateDropTypeID": 58,
+            "CrateDropTypeID": 55,
             "MiscDropChanceID": 0,
-            "MiscDropTypeID": 66
+            "MiscDropTypeID": 104
         },
-        "229": {
-            "MobDropID": 267,
+        "1040": {
+            "MobDropID": 1040,
             "CrateDropChanceID": 0,
-            "CrateDropTypeID": 58,
-            "MiscDropChanceID": 0,
-            "MiscDropTypeID": 66
-        },
-        "230": {
-            "MobDropID": 268,
-            "CrateDropChanceID": 0,
-            "CrateDropTypeID": 58,
-            "MiscDropChanceID": 0,
-            "MiscDropTypeID": 67
-        },
-        "231": {
-            "MobDropID": 270,
-            "CrateDropChanceID": 0,
-            "CrateDropTypeID": 59,
-            "MiscDropChanceID": 0,
-            "MiscDropTypeID": 68
-        },
-        "232": {
-            "MobDropID": 271,
-            "CrateDropChanceID": 0,
-            "CrateDropTypeID": 59,
-            "MiscDropChanceID": 0,
-            "MiscDropTypeID": 68
-        },
-        "233": {
-            "MobDropID": 272,
-            "CrateDropChanceID": 0,
-            "CrateDropTypeID": 59,
+            "CrateDropTypeID": 26,
             "MiscDropChanceID": 0,
             "MiscDropTypeID": 105
         },
-        "234": {
-            "MobDropID": 273,
+        "1041": {
+            "MobDropID": 1041,
             "CrateDropChanceID": 0,
-            "CrateDropTypeID": 59,
+            "CrateDropTypeID": 56,
             "MiscDropChanceID": 0,
-            "MiscDropTypeID": 68
+            "MiscDropTypeID": 105
         },
-        "235": {
-            "MobDropID": 274,
+        "1042": {
+            "MobDropID": 1042,
             "CrateDropChanceID": 0,
-            "CrateDropTypeID": 60,
+            "CrateDropTypeID": 82,
             "MiscDropChanceID": 0,
-            "MiscDropTypeID": 72
+            "MiscDropTypeID": 105
         },
-        "236": {
-            "MobDropID": 275,
+        "1050": {
+            "MobDropID": 1050,
             "CrateDropChanceID": 0,
-            "CrateDropTypeID": 60,
-            "MiscDropChanceID": 0,
-            "MiscDropTypeID": 72
-        },
-        "237": {
-            "MobDropID": 276,
-            "CrateDropChanceID": 0,
-            "CrateDropTypeID": 60,
-            "MiscDropChanceID": 0,
-            "MiscDropTypeID": 71
-        },
-        "238": {
-            "MobDropID": 278,
-            "CrateDropChanceID": 0,
-            "CrateDropTypeID": 61,
-            "MiscDropChanceID": 0,
-            "MiscDropTypeID": 73
-        },
-        "239": {
-            "MobDropID": 279,
-            "CrateDropChanceID": 0,
-            "CrateDropTypeID": 61,
-            "MiscDropChanceID": 0,
-            "MiscDropTypeID": 73
-        },
-        "240": {
-            "MobDropID": 280,
-            "CrateDropChanceID": 0,
-            "CrateDropTypeID": 61,
+            "CrateDropTypeID": 26,
             "MiscDropChanceID": 0,
             "MiscDropTypeID": 106
         },
-        "241": {
-            "MobDropID": 281,
+        "1060": {
+            "MobDropID": 1060,
             "CrateDropChanceID": 0,
-            "CrateDropTypeID": 61,
-            "MiscDropChanceID": 0,
-            "MiscDropTypeID": 73
-        },
-        "242": {
-            "MobDropID": 282,
-            "CrateDropChanceID": 0,
-            "CrateDropTypeID": 62,
+            "CrateDropTypeID": 26,
             "MiscDropChanceID": 0,
             "MiscDropTypeID": 107
         },
-        "243": {
-            "MobDropID": 283,
+        "1061": {
+            "MobDropID": 1061,
             "CrateDropChanceID": 0,
-            "CrateDropTypeID": 62,
+            "CrateDropTypeID": 56,
             "MiscDropChanceID": 0,
             "MiscDropTypeID": 107
         },
-        "244": {
-            "MobDropID": 284,
+        "1062": {
+            "MobDropID": 1062,
             "CrateDropChanceID": 0,
-            "CrateDropTypeID": 62,
+            "CrateDropTypeID": 82,
+            "MiscDropChanceID": 0,
+            "MiscDropTypeID": 107
+        },
+        "1070": {
+            "MobDropID": 1070,
+            "CrateDropChanceID": 0,
+            "CrateDropTypeID": 26,
             "MiscDropChanceID": 0,
             "MiscDropTypeID": 108
         },
-        "245": {
-            "MobDropID": 285,
+        "1071": {
+            "MobDropID": 1071,
             "CrateDropChanceID": 0,
-            "CrateDropTypeID": 62,
+            "CrateDropTypeID": 56,
             "MiscDropChanceID": 0,
-            "MiscDropTypeID": 75
+            "MiscDropTypeID": 108
         },
-        "246": {
-            "MobDropID": 286,
+        "1080": {
+            "MobDropID": 1080,
             "CrateDropChanceID": 0,
-            "CrateDropTypeID": 63,
-            "MiscDropChanceID": 0,
-            "MiscDropTypeID": 77
-        },
-        "247": {
-            "MobDropID": 287,
-            "CrateDropChanceID": 0,
-            "CrateDropTypeID": 63,
-            "MiscDropChanceID": 0,
-            "MiscDropTypeID": 77
-        },
-        "248": {
-            "MobDropID": 288,
-            "CrateDropChanceID": 0,
-            "CrateDropTypeID": 63,
-            "MiscDropChanceID": 0,
-            "MiscDropTypeID": 79
-        },
-        "249": {
-            "MobDropID": 289,
-            "CrateDropChanceID": 0,
-            "CrateDropTypeID": 63,
-            "MiscDropChanceID": 0,
-            "MiscDropTypeID": 78
-        },
-        "250": {
-            "MobDropID": 290,
-            "CrateDropChanceID": 0,
-            "CrateDropTypeID": 64,
+            "CrateDropTypeID": 27,
             "MiscDropChanceID": 0,
             "MiscDropTypeID": 109
         },
-        "251": {
-            "MobDropID": 291,
+        "1081": {
+            "MobDropID": 1081,
             "CrateDropChanceID": 0,
-            "CrateDropTypeID": 64,
+            "CrateDropTypeID": 57,
             "MiscDropChanceID": 0,
             "MiscDropTypeID": 109
         },
-        "252": {
-            "MobDropID": 292,
+        "1082": {
+            "MobDropID": 1082,
             "CrateDropChanceID": 0,
-            "CrateDropTypeID": 64,
+            "CrateDropTypeID": 83,
             "MiscDropChanceID": 0,
-            "MiscDropTypeID": 81
+            "MiscDropTypeID": 109
         },
-        "253": {
-            "MobDropID": 293,
+        "1090": {
+            "MobDropID": 1090,
             "CrateDropChanceID": 0,
-            "CrateDropTypeID": 64,
-            "MiscDropChanceID": 0,
-            "MiscDropTypeID": 80
-        },
-        "254": {
-            "MobDropID": 294,
-            "CrateDropChanceID": 0,
-            "CrateDropTypeID": 65,
+            "CrateDropTypeID": 27,
             "MiscDropChanceID": 0,
             "MiscDropTypeID": 110
         },
-        "255": {
-            "MobDropID": 295,
+        "1091": {
+            "MobDropID": 1091,
             "CrateDropChanceID": 0,
-            "CrateDropTypeID": 65,
+            "CrateDropTypeID": 57,
             "MiscDropChanceID": 0,
             "MiscDropTypeID": 110
         },
-        "256": {
-            "MobDropID": 296,
+        "1092": {
+            "MobDropID": 1092,
             "CrateDropChanceID": 0,
-            "CrateDropTypeID": 65,
+            "CrateDropTypeID": 83,
             "MiscDropChanceID": 0,
-            "MiscDropTypeID": 83
+            "MiscDropTypeID": 110
         },
-        "257": {
-            "MobDropID": 338,
+        "1100": {
+            "MobDropID": 1100,
             "CrateDropChanceID": 0,
-            "CrateDropTypeID": 66,
-            "MiscDropChanceID": 0,
-            "MiscDropTypeID": 27
-        },
-        "258": {
-            "MobDropID": 339,
-            "CrateDropChanceID": 0,
-            "CrateDropTypeID": 66,
-            "MiscDropChanceID": 0,
-            "MiscDropTypeID": 27
-        },
-        "259": {
-            "MobDropID": 340,
-            "CrateDropChanceID": 0,
-            "CrateDropTypeID": 66,
-            "MiscDropChanceID": 0,
-            "MiscDropTypeID": 30
-        },
-        "260": {
-            "MobDropID": 342,
-            "CrateDropChanceID": 0,
-            "CrateDropTypeID": 67,
-            "MiscDropChanceID": 0,
-            "MiscDropTypeID": 29
-        },
-        "261": {
-            "MobDropID": 343,
-            "CrateDropChanceID": 0,
-            "CrateDropTypeID": 67,
-            "MiscDropChanceID": 0,
-            "MiscDropTypeID": 29
-        },
-        "262": {
-            "MobDropID": 344,
-            "CrateDropChanceID": 0,
-            "CrateDropTypeID": 67,
-            "MiscDropChanceID": 0,
-            "MiscDropTypeID": 30
-        },
-        "263": {
-            "MobDropID": 345,
-            "CrateDropChanceID": 0,
-            "CrateDropTypeID": 67,
-            "MiscDropChanceID": 0,
-            "MiscDropTypeID": 31
-        },
-        "264": {
-            "MobDropID": 346,
-            "CrateDropChanceID": 0,
-            "CrateDropTypeID": 68,
-            "MiscDropChanceID": 0,
-            "MiscDropTypeID": 32
-        },
-        "265": {
-            "MobDropID": 347,
-            "CrateDropChanceID": 0,
-            "CrateDropTypeID": 68,
-            "MiscDropChanceID": 0,
-            "MiscDropTypeID": 32
-        },
-        "266": {
-            "MobDropID": 348,
-            "CrateDropChanceID": 0,
-            "CrateDropTypeID": 68,
-            "MiscDropChanceID": 0,
-            "MiscDropTypeID": 33
-        },
-        "267": {
-            "MobDropID": 349,
-            "CrateDropChanceID": 0,
-            "CrateDropTypeID": 68,
-            "MiscDropChanceID": 0,
-            "MiscDropTypeID": 34
-        },
-        "268": {
-            "MobDropID": 350,
-            "CrateDropChanceID": 0,
-            "CrateDropTypeID": 69,
-            "MiscDropChanceID": 0,
-            "MiscDropTypeID": 34
-        },
-        "269": {
-            "MobDropID": 351,
-            "CrateDropChanceID": 0,
-            "CrateDropTypeID": 69,
-            "MiscDropChanceID": 0,
-            "MiscDropTypeID": 34
-        },
-        "270": {
-            "MobDropID": 352,
-            "CrateDropChanceID": 0,
-            "CrateDropTypeID": 69,
-            "MiscDropChanceID": 0,
-            "MiscDropTypeID": 33
-        },
-        "271": {
-            "MobDropID": 354,
-            "CrateDropChanceID": 0,
-            "CrateDropTypeID": 70,
+            "CrateDropTypeID": 27,
             "MiscDropChanceID": 0,
             "MiscDropTypeID": 111
         },
-        "272": {
-            "MobDropID": 355,
+        "1101": {
+            "MobDropID": 1101,
             "CrateDropChanceID": 0,
-            "CrateDropTypeID": 70,
+            "CrateDropTypeID": 57,
             "MiscDropChanceID": 0,
             "MiscDropTypeID": 111
         },
-        "273": {
-            "MobDropID": 356,
+        "1102": {
+            "MobDropID": 1102,
             "CrateDropChanceID": 0,
-            "CrateDropTypeID": 70,
+            "CrateDropTypeID": 83,
+            "MiscDropChanceID": 0,
+            "MiscDropTypeID": 111
+        },
+        "1110": {
+            "MobDropID": 1110,
+            "CrateDropChanceID": 0,
+            "CrateDropTypeID": 27,
             "MiscDropChanceID": 0,
             "MiscDropTypeID": 112
         },
-        "274": {
-            "MobDropID": 357,
+        "1120": {
+            "MobDropID": 1120,
             "CrateDropChanceID": 0,
-            "CrateDropTypeID": 70,
-            "MiscDropChanceID": 0,
-            "MiscDropTypeID": 38
-        },
-        "275": {
-            "MobDropID": 358,
-            "CrateDropChanceID": 0,
-            "CrateDropTypeID": 71,
-            "MiscDropChanceID": 0,
-            "MiscDropTypeID": 39
-        },
-        "276": {
-            "MobDropID": 359,
-            "CrateDropChanceID": 0,
-            "CrateDropTypeID": 71,
-            "MiscDropChanceID": 0,
-            "MiscDropTypeID": 39
-        },
-        "277": {
-            "MobDropID": 360,
-            "CrateDropChanceID": 0,
-            "CrateDropTypeID": 71,
-            "MiscDropChanceID": 0,
-            "MiscDropTypeID": 40
-        },
-        "278": {
-            "MobDropID": 361,
-            "CrateDropChanceID": 0,
-            "CrateDropTypeID": 71,
-            "MiscDropChanceID": 0,
-            "MiscDropTypeID": 39
-        },
-        "279": {
-            "MobDropID": 362,
-            "CrateDropChanceID": 0,
-            "CrateDropTypeID": 72,
-            "MiscDropChanceID": 0,
-            "MiscDropTypeID": 90
-        },
-        "280": {
-            "MobDropID": 363,
-            "CrateDropChanceID": 0,
-            "CrateDropTypeID": 72,
-            "MiscDropChanceID": 0,
-            "MiscDropTypeID": 90
-        },
-        "281": {
-            "MobDropID": 364,
-            "CrateDropChanceID": 0,
-            "CrateDropTypeID": 72,
-            "MiscDropChanceID": 0,
-            "MiscDropTypeID": 42
-        },
-        "282": {
-            "MobDropID": 365,
-            "CrateDropChanceID": 0,
-            "CrateDropTypeID": 72,
-            "MiscDropChanceID": 0,
-            "MiscDropTypeID": 41
-        },
-        "283": {
-            "MobDropID": 366,
-            "CrateDropChanceID": 0,
-            "CrateDropTypeID": 73,
-            "MiscDropChanceID": 0,
-            "MiscDropTypeID": 43
-        },
-        "284": {
-            "MobDropID": 367,
-            "CrateDropChanceID": 0,
-            "CrateDropTypeID": 73,
-            "MiscDropChanceID": 0,
-            "MiscDropTypeID": 43
-        },
-        "285": {
-            "MobDropID": 368,
-            "CrateDropChanceID": 0,
-            "CrateDropTypeID": 73,
-            "MiscDropChanceID": 0,
-            "MiscDropTypeID": 44
-        },
-        "286": {
-            "MobDropID": 369,
-            "CrateDropChanceID": 0,
-            "CrateDropTypeID": 73,
-            "MiscDropChanceID": 0,
-            "MiscDropTypeID": 93
-        },
-        "287": {
-            "MobDropID": 370,
-            "CrateDropChanceID": 0,
-            "CrateDropTypeID": 74,
-            "MiscDropChanceID": 0,
-            "MiscDropTypeID": 45
-        },
-        "288": {
-            "MobDropID": 371,
-            "CrateDropChanceID": 0,
-            "CrateDropTypeID": 74,
-            "MiscDropChanceID": 0,
-            "MiscDropTypeID": 45
-        },
-        "289": {
-            "MobDropID": 372,
-            "CrateDropChanceID": 0,
-            "CrateDropTypeID": 74,
-            "MiscDropChanceID": 0,
-            "MiscDropTypeID": 46
-        },
-        "290": {
-            "MobDropID": 374,
-            "CrateDropChanceID": 0,
-            "CrateDropTypeID": 75,
-            "MiscDropChanceID": 0,
-            "MiscDropTypeID": 96
-        },
-        "291": {
-            "MobDropID": 375,
-            "CrateDropChanceID": 0,
-            "CrateDropTypeID": 75,
-            "MiscDropChanceID": 0,
-            "MiscDropTypeID": 96
-        },
-        "292": {
-            "MobDropID": 376,
-            "CrateDropChanceID": 0,
-            "CrateDropTypeID": 75,
-            "MiscDropChanceID": 0,
-            "MiscDropTypeID": 48
-        },
-        "293": {
-            "MobDropID": 377,
-            "CrateDropChanceID": 0,
-            "CrateDropTypeID": 76,
-            "MiscDropChanceID": 0,
-            "MiscDropTypeID": 55
-        },
-        "294": {
-            "MobDropID": 378,
-            "CrateDropChanceID": 0,
-            "CrateDropTypeID": 77,
-            "MiscDropChanceID": 0,
-            "MiscDropTypeID": 97
-        },
-        "295": {
-            "MobDropID": 379,
-            "CrateDropChanceID": 0,
-            "CrateDropTypeID": 77,
-            "MiscDropChanceID": 0,
-            "MiscDropTypeID": 97
-        },
-        "296": {
-            "MobDropID": 380,
-            "CrateDropChanceID": 0,
-            "CrateDropTypeID": 77,
-            "MiscDropChanceID": 0,
-            "MiscDropTypeID": 50
-        },
-        "297": {
-            "MobDropID": 381,
-            "CrateDropChanceID": 0,
-            "CrateDropTypeID": 77,
-            "MiscDropChanceID": 0,
-            "MiscDropTypeID": 49
-        },
-        "298": {
-            "MobDropID": 382,
-            "CrateDropChanceID": 0,
-            "CrateDropTypeID": 78,
-            "MiscDropChanceID": 0,
-            "MiscDropTypeID": 51
-        },
-        "299": {
-            "MobDropID": 383,
-            "CrateDropChanceID": 0,
-            "CrateDropTypeID": 78,
-            "MiscDropChanceID": 0,
-            "MiscDropTypeID": 51
-        },
-        "300": {
-            "MobDropID": 384,
-            "CrateDropChanceID": 0,
-            "CrateDropTypeID": 78,
-            "MiscDropChanceID": 0,
-            "MiscDropTypeID": 52
-        },
-        "301": {
-            "MobDropID": 385,
-            "CrateDropChanceID": 0,
-            "CrateDropTypeID": 78,
-            "MiscDropChanceID": 0,
-            "MiscDropTypeID": 51
-        },
-        "302": {
-            "MobDropID": 386,
-            "CrateDropChanceID": 0,
-            "CrateDropTypeID": 79,
-            "MiscDropChanceID": 0,
-            "MiscDropTypeID": 53
-        },
-        "303": {
-            "MobDropID": 387,
-            "CrateDropChanceID": 0,
-            "CrateDropTypeID": 79,
-            "MiscDropChanceID": 0,
-            "MiscDropTypeID": 53
-        },
-        "304": {
-            "MobDropID": 388,
-            "CrateDropChanceID": 0,
-            "CrateDropTypeID": 79,
-            "MiscDropChanceID": 0,
-            "MiscDropTypeID": 54
-        },
-        "305": {
-            "MobDropID": 389,
-            "CrateDropChanceID": 0,
-            "CrateDropTypeID": 79,
-            "MiscDropChanceID": 0,
-            "MiscDropTypeID": 53
-        },
-        "306": {
-            "MobDropID": 390,
-            "CrateDropChanceID": 0,
-            "CrateDropTypeID": 76,
-            "MiscDropChanceID": 0,
-            "MiscDropTypeID": 55
-        },
-        "307": {
-            "MobDropID": 391,
-            "CrateDropChanceID": 0,
-            "CrateDropTypeID": 76,
-            "MiscDropChanceID": 0,
-            "MiscDropTypeID": 55
-        },
-        "308": {
-            "MobDropID": 392,
-            "CrateDropChanceID": 0,
-            "CrateDropTypeID": 76,
+            "CrateDropTypeID": 28,
             "MiscDropChanceID": 0,
             "MiscDropTypeID": 113
         },
-        "309": {
-            "MobDropID": 393,
+        "1121": {
+            "MobDropID": 1121,
             "CrateDropChanceID": 0,
-            "CrateDropTypeID": 76,
+            "CrateDropTypeID": 58,
             "MiscDropChanceID": 0,
-            "MiscDropTypeID": 55
+            "MiscDropTypeID": 113
         },
-        "310": {
-            "MobDropID": 394,
+        "1130": {
+            "MobDropID": 1130,
             "CrateDropChanceID": 0,
-            "CrateDropTypeID": 80,
-            "MiscDropChanceID": 0,
-            "MiscDropTypeID": 59
-        },
-        "311": {
-            "MobDropID": 395,
-            "CrateDropChanceID": 0,
-            "CrateDropTypeID": 80,
-            "MiscDropChanceID": 0,
-            "MiscDropTypeID": 59
-        },
-        "312": {
-            "MobDropID": 396,
-            "CrateDropChanceID": 0,
-            "CrateDropTypeID": 80,
-            "MiscDropChanceID": 0,
-            "MiscDropTypeID": 58
-        },
-        "313": {
-            "MobDropID": 397,
-            "CrateDropChanceID": 0,
-            "CrateDropTypeID": 80,
-            "MiscDropChanceID": 0,
-            "MiscDropTypeID": 59
-        },
-        "314": {
-            "MobDropID": 398,
-            "CrateDropChanceID": 0,
-            "CrateDropTypeID": 81,
-            "MiscDropChanceID": 0,
-            "MiscDropTypeID": 102
-        },
-        "315": {
-            "MobDropID": 399,
-            "CrateDropChanceID": 0,
-            "CrateDropTypeID": 81,
-            "MiscDropChanceID": 0,
-            "MiscDropTypeID": 102
-        },
-        "316": {
-            "MobDropID": 400,
-            "CrateDropChanceID": 0,
-            "CrateDropTypeID": 81,
-            "MiscDropChanceID": 0,
-            "MiscDropTypeID": 61
-        },
-        "317": {
-            "MobDropID": 402,
-            "CrateDropChanceID": 0,
-            "CrateDropTypeID": 82,
+            "CrateDropTypeID": 28,
             "MiscDropChanceID": 0,
             "MiscDropTypeID": 114
         },
-        "318": {
-            "MobDropID": 403,
+        "1131": {
+            "MobDropID": 1131,
             "CrateDropChanceID": 0,
-            "CrateDropTypeID": 82,
+            "CrateDropTypeID": 84,
             "MiscDropChanceID": 0,
             "MiscDropTypeID": 114
         },
-        "319": {
-            "MobDropID": 404,
+        "1140": {
+            "MobDropID": 1140,
             "CrateDropChanceID": 0,
-            "CrateDropTypeID": 82,
+            "CrateDropTypeID": 28,
             "MiscDropChanceID": 0,
-            "MiscDropTypeID": 103
+            "MiscDropTypeID": 115
         },
-        "320": {
-            "MobDropID": 406,
+        "1141": {
+            "MobDropID": 1141,
             "CrateDropChanceID": 0,
-            "CrateDropTypeID": 83,
+            "CrateDropTypeID": 58,
             "MiscDropChanceID": 0,
-            "MiscDropTypeID": 63
+            "MiscDropTypeID": 115
         },
-        "321": {
-            "MobDropID": 407,
-            "CrateDropChanceID": 0,
-            "CrateDropTypeID": 83,
-            "MiscDropChanceID": 0,
-            "MiscDropTypeID": 63
-        },
-        "322": {
-            "MobDropID": 408,
-            "CrateDropChanceID": 0,
-            "CrateDropTypeID": 83,
-            "MiscDropChanceID": 0,
-            "MiscDropTypeID": 104
-        },
-        "323": {
-            "MobDropID": 410,
+        "1142": {
+            "MobDropID": 1142,
             "CrateDropChanceID": 0,
             "CrateDropTypeID": 84,
             "MiscDropChanceID": 0,
             "MiscDropTypeID": 115
         },
-        "324": {
-            "MobDropID": 411,
+        "1150": {
+            "MobDropID": 1150,
             "CrateDropChanceID": 0,
-            "CrateDropTypeID": 84,
-            "MiscDropChanceID": 0,
-            "MiscDropTypeID": 115
-        },
-        "325": {
-            "MobDropID": 412,
-            "CrateDropChanceID": 0,
-            "CrateDropTypeID": 84,
-            "MiscDropChanceID": 0,
-            "MiscDropTypeID": 67
-        },
-        "326": {
-            "MobDropID": 415,
-            "CrateDropChanceID": 0,
-            "CrateDropTypeID": 85,
+            "CrateDropTypeID": 28,
             "MiscDropChanceID": 0,
             "MiscDropTypeID": 116
         },
-        "327": {
-            "MobDropID": 417,
+        "1160": {
+            "MobDropID": 1160,
             "CrateDropChanceID": 0,
-            "CrateDropTypeID": 85,
-            "MiscDropChanceID": 0,
-            "MiscDropTypeID": 68
-        },
-        "328": {
-            "MobDropID": 420,
-            "CrateDropChanceID": 0,
-            "CrateDropTypeID": 86,
-            "MiscDropChanceID": 0,
-            "MiscDropTypeID": 71
-        },
-        "329": {
-            "MobDropID": 422,
-            "CrateDropChanceID": 0,
-            "CrateDropTypeID": 87,
-            "MiscDropChanceID": 0,
-            "MiscDropTypeID": 73
-        },
-        "330": {
-            "MobDropID": 423,
-            "CrateDropChanceID": 0,
-            "CrateDropTypeID": 87,
-            "MiscDropChanceID": 0,
-            "MiscDropTypeID": 73
-        },
-        "331": {
-            "MobDropID": 424,
-            "CrateDropChanceID": 0,
-            "CrateDropTypeID": 87,
-            "MiscDropChanceID": 0,
-            "MiscDropTypeID": 74
-        },
-        "332": {
-            "MobDropID": 425,
-            "CrateDropChanceID": 0,
-            "CrateDropTypeID": 87,
-            "MiscDropChanceID": 0,
-            "MiscDropTypeID": 73
-        },
-        "333": {
-            "MobDropID": 426,
-            "CrateDropChanceID": 0,
-            "CrateDropTypeID": 88,
-            "MiscDropChanceID": 0,
-            "MiscDropTypeID": 107
-        },
-        "334": {
-            "MobDropID": 427,
-            "CrateDropChanceID": 0,
-            "CrateDropTypeID": 88,
-            "MiscDropChanceID": 0,
-            "MiscDropTypeID": 107
-        },
-        "335": {
-            "MobDropID": 428,
-            "CrateDropChanceID": 0,
-            "CrateDropTypeID": 88,
-            "MiscDropChanceID": 0,
-            "MiscDropTypeID": 76
-        },
-        "336": {
-            "MobDropID": 429,
-            "CrateDropChanceID": 0,
-            "CrateDropTypeID": 88,
-            "MiscDropChanceID": 0,
-            "MiscDropTypeID": 75
-        },
-        "337": {
-            "MobDropID": 430,
-            "CrateDropChanceID": 0,
-            "CrateDropTypeID": 89,
-            "MiscDropChanceID": 0,
-            "MiscDropTypeID": 77
-        },
-        "338": {
-            "MobDropID": 431,
-            "CrateDropChanceID": 0,
-            "CrateDropTypeID": 89,
-            "MiscDropChanceID": 0,
-            "MiscDropTypeID": 77
-        },
-        "339": {
-            "MobDropID": 432,
-            "CrateDropChanceID": 0,
-            "CrateDropTypeID": 89,
-            "MiscDropChanceID": 0,
-            "MiscDropTypeID": 79
-        },
-        "340": {
-            "MobDropID": 434,
-            "CrateDropChanceID": 0,
-            "CrateDropTypeID": 90,
-            "MiscDropChanceID": 0,
-            "MiscDropTypeID": 109
-        },
-        "341": {
-            "MobDropID": 435,
-            "CrateDropChanceID": 0,
-            "CrateDropTypeID": 90,
-            "MiscDropChanceID": 0,
-            "MiscDropTypeID": 109
-        },
-        "342": {
-            "MobDropID": 436,
-            "CrateDropChanceID": 0,
-            "CrateDropTypeID": 90,
-            "MiscDropChanceID": 0,
-            "MiscDropTypeID": 81
-        },
-        "343": {
-            "MobDropID": 438,
-            "CrateDropChanceID": 0,
-            "CrateDropTypeID": 91,
-            "MiscDropChanceID": 0,
-            "MiscDropTypeID": 110
-        },
-        "344": {
-            "MobDropID": 439,
-            "CrateDropChanceID": 0,
-            "CrateDropTypeID": 91,
-            "MiscDropChanceID": 0,
-            "MiscDropTypeID": 82
-        },
-        "345": {
-            "MobDropID": 440,
-            "CrateDropChanceID": 0,
-            "CrateDropTypeID": 91,
-            "MiscDropChanceID": 0,
-            "MiscDropTypeID": 83
-        },
-        "346": {
-            "MobDropID": 699,
-            "CrateDropChanceID": 1,
-            "CrateDropTypeID": 92,
+            "CrateDropTypeID": 29,
             "MiscDropChanceID": 0,
             "MiscDropTypeID": 117
         },
-        "347": {
-            "MobDropID": 700,
-            "CrateDropChanceID": 1,
-            "CrateDropTypeID": 93,
+        "1161": {
+            "MobDropID": 1161,
+            "CrateDropChanceID": 0,
+            "CrateDropTypeID": 30,
             "MiscDropChanceID": 0,
             "MiscDropTypeID": 117
         },
-        "348": {
-            "MobDropID": 701,
-            "CrateDropChanceID": 1,
-            "CrateDropTypeID": 94,
+        "1162": {
+            "MobDropID": 1162,
+            "CrateDropChanceID": 0,
+            "CrateDropTypeID": 59,
+            "MiscDropChanceID": 0,
+            "MiscDropTypeID": 117
+        },
+        "1170": {
+            "MobDropID": 1170,
+            "CrateDropChanceID": 0,
+            "CrateDropTypeID": 29,
             "MiscDropChanceID": 0,
             "MiscDropTypeID": 118
         },
-        "349": {
-            "MobDropID": 702,
-            "CrateDropChanceID": 1,
-            "CrateDropTypeID": 95,
+        "1171": {
+            "MobDropID": 1171,
+            "CrateDropChanceID": 0,
+            "CrateDropTypeID": 59,
+            "MiscDropChanceID": 0,
+            "MiscDropTypeID": 118
+        },
+        "1180": {
+            "MobDropID": 1180,
+            "CrateDropChanceID": 0,
+            "CrateDropTypeID": 29,
             "MiscDropChanceID": 0,
             "MiscDropTypeID": 119
         },
-        "350": {
-            "MobDropID": 703,
-            "CrateDropChanceID": 1,
-            "CrateDropTypeID": 96,
+        "1181": {
+            "MobDropID": 1181,
+            "CrateDropChanceID": 0,
+            "CrateDropTypeID": 59,
+            "MiscDropChanceID": 0,
+            "MiscDropTypeID": 119
+        },
+        "1190": {
+            "MobDropID": 1190,
+            "CrateDropChanceID": 0,
+            "CrateDropTypeID": 29,
             "MiscDropChanceID": 0,
             "MiscDropTypeID": 120
         },
-        "351": {
-            "MobDropID": 704,
-            "CrateDropChanceID": 1,
-            "CrateDropTypeID": 97,
+        "1191": {
+            "MobDropID": 1191,
+            "CrateDropChanceID": 0,
+            "CrateDropTypeID": 85,
+            "MiscDropChanceID": 0,
+            "MiscDropTypeID": 120
+        },
+        "1200": {
+            "MobDropID": 1200,
+            "CrateDropChanceID": 0,
+            "CrateDropTypeID": 60,
             "MiscDropChanceID": 0,
             "MiscDropTypeID": 121
         },
-        "352": {
-            "MobDropID": 705,
-            "CrateDropChanceID": 1,
-            "CrateDropTypeID": 98,
+        "1210": {
+            "MobDropID": 1210,
+            "CrateDropChanceID": 0,
+            "CrateDropTypeID": 29,
             "MiscDropChanceID": 0,
             "MiscDropTypeID": 122
         },
-        "353": {
-            "MobDropID": 706,
+        "1211": {
+            "MobDropID": 1211,
+            "CrateDropChanceID": 0,
+            "CrateDropTypeID": 30,
+            "MiscDropChanceID": 0,
+            "MiscDropTypeID": 122
+        },
+        "1212": {
+            "MobDropID": 1212,
+            "CrateDropChanceID": 0,
+            "CrateDropTypeID": 60,
+            "MiscDropChanceID": 0,
+            "MiscDropTypeID": 122
+        },
+        "1220": {
+            "MobDropID": 1220,
+            "CrateDropChanceID": 0,
+            "CrateDropTypeID": 30,
+            "MiscDropChanceID": 0,
+            "MiscDropTypeID": 123
+        },
+        "1221": {
+            "MobDropID": 1221,
+            "CrateDropChanceID": 0,
+            "CrateDropTypeID": 60,
+            "MiscDropChanceID": 0,
+            "MiscDropTypeID": 123
+        },
+        "1222": {
+            "MobDropID": 1222,
+            "CrateDropChanceID": 0,
+            "CrateDropTypeID": 86,
+            "MiscDropChanceID": 0,
+            "MiscDropTypeID": 123
+        },
+        "1230": {
+            "MobDropID": 1230,
+            "CrateDropChanceID": 0,
+            "CrateDropTypeID": 30,
+            "MiscDropChanceID": 0,
+            "MiscDropTypeID": 124
+        },
+        "1240": {
+            "MobDropID": 1240,
+            "CrateDropChanceID": 0,
+            "CrateDropTypeID": 31,
+            "MiscDropChanceID": 0,
+            "MiscDropTypeID": 125
+        },
+        "1241": {
+            "MobDropID": 1241,
+            "CrateDropChanceID": 0,
+            "CrateDropTypeID": 61,
+            "MiscDropChanceID": 0,
+            "MiscDropTypeID": 125
+        },
+        "1242": {
+            "MobDropID": 1242,
+            "CrateDropChanceID": 0,
+            "CrateDropTypeID": 87,
+            "MiscDropChanceID": 0,
+            "MiscDropTypeID": 125
+        },
+        "1250": {
+            "MobDropID": 1250,
+            "CrateDropChanceID": 0,
+            "CrateDropTypeID": 31,
+            "MiscDropChanceID": 0,
+            "MiscDropTypeID": 126
+        },
+        "1260": {
+            "MobDropID": 1260,
+            "CrateDropChanceID": 0,
+            "CrateDropTypeID": 31,
+            "MiscDropChanceID": 0,
+            "MiscDropTypeID": 127
+        },
+        "1261": {
+            "MobDropID": 1261,
+            "CrateDropChanceID": 0,
+            "CrateDropTypeID": 61,
+            "MiscDropChanceID": 0,
+            "MiscDropTypeID": 127
+        },
+        "1262": {
+            "MobDropID": 1262,
+            "CrateDropChanceID": 0,
+            "CrateDropTypeID": 87,
+            "MiscDropChanceID": 0,
+            "MiscDropTypeID": 127
+        },
+        "1270": {
+            "MobDropID": 1270,
+            "CrateDropChanceID": 0,
+            "CrateDropTypeID": 31,
+            "MiscDropChanceID": 0,
+            "MiscDropTypeID": 128
+        },
+        "1271": {
+            "MobDropID": 1271,
+            "CrateDropChanceID": 0,
+            "CrateDropTypeID": 61,
+            "MiscDropChanceID": 0,
+            "MiscDropTypeID": 128
+        },
+        "1272": {
+            "MobDropID": 1272,
+            "CrateDropChanceID": 0,
+            "CrateDropTypeID": 87,
+            "MiscDropChanceID": 0,
+            "MiscDropTypeID": 128
+        },
+        "1280": {
+            "MobDropID": 1280,
+            "CrateDropChanceID": 0,
+            "CrateDropTypeID": 32,
+            "MiscDropChanceID": 0,
+            "MiscDropTypeID": 129
+        },
+        "1281": {
+            "MobDropID": 1281,
+            "CrateDropChanceID": 0,
+            "CrateDropTypeID": 62,
+            "MiscDropChanceID": 0,
+            "MiscDropTypeID": 129
+        },
+        "1282": {
+            "MobDropID": 1282,
+            "CrateDropChanceID": 0,
+            "CrateDropTypeID": 88,
+            "MiscDropChanceID": 0,
+            "MiscDropTypeID": 129
+        },
+        "1290": {
+            "MobDropID": 1290,
+            "CrateDropChanceID": 0,
+            "CrateDropTypeID": 62,
+            "MiscDropChanceID": 0,
+            "MiscDropTypeID": 130
+        },
+        "1300": {
+            "MobDropID": 1300,
+            "CrateDropChanceID": 0,
+            "CrateDropTypeID": 32,
+            "MiscDropChanceID": 0,
+            "MiscDropTypeID": 131
+        },
+        "1301": {
+            "MobDropID": 1301,
+            "CrateDropChanceID": 0,
+            "CrateDropTypeID": 62,
+            "MiscDropChanceID": 0,
+            "MiscDropTypeID": 131
+        },
+        "1302": {
+            "MobDropID": 1302,
+            "CrateDropChanceID": 0,
+            "CrateDropTypeID": 88,
+            "MiscDropChanceID": 0,
+            "MiscDropTypeID": 131
+        },
+        "1310": {
+            "MobDropID": 1310,
+            "CrateDropChanceID": 0,
+            "CrateDropTypeID": 32,
+            "MiscDropChanceID": 0,
+            "MiscDropTypeID": 132
+        },
+        "1311": {
+            "MobDropID": 1311,
+            "CrateDropChanceID": 0,
+            "CrateDropTypeID": 62,
+            "MiscDropChanceID": 0,
+            "MiscDropTypeID": 132
+        },
+        "1312": {
+            "MobDropID": 1312,
+            "CrateDropChanceID": 0,
+            "CrateDropTypeID": 88,
+            "MiscDropChanceID": 0,
+            "MiscDropTypeID": 132
+        },
+        "1320": {
+            "MobDropID": 1320,
+            "CrateDropChanceID": 0,
+            "CrateDropTypeID": 33,
+            "MiscDropChanceID": 0,
+            "MiscDropTypeID": 133
+        },
+        "1321": {
+            "MobDropID": 1321,
+            "CrateDropChanceID": 0,
+            "CrateDropTypeID": 63,
+            "MiscDropChanceID": 0,
+            "MiscDropTypeID": 133
+        },
+        "1322": {
+            "MobDropID": 1322,
+            "CrateDropChanceID": 0,
+            "CrateDropTypeID": 89,
+            "MiscDropChanceID": 0,
+            "MiscDropTypeID": 133
+        },
+        "1330": {
+            "MobDropID": 1330,
+            "CrateDropChanceID": 0,
+            "CrateDropTypeID": 33,
+            "MiscDropChanceID": 0,
+            "MiscDropTypeID": 134
+        },
+        "1331": {
+            "MobDropID": 1331,
+            "CrateDropChanceID": 0,
+            "CrateDropTypeID": 89,
+            "MiscDropChanceID": 0,
+            "MiscDropTypeID": 134
+        },
+        "1340": {
+            "MobDropID": 1340,
+            "CrateDropChanceID": 0,
+            "CrateDropTypeID": 33,
+            "MiscDropChanceID": 0,
+            "MiscDropTypeID": 135
+        },
+        "1341": {
+            "MobDropID": 1341,
+            "CrateDropChanceID": 0,
+            "CrateDropTypeID": 63,
+            "MiscDropChanceID": 0,
+            "MiscDropTypeID": 135
+        },
+        "1342": {
+            "MobDropID": 1342,
+            "CrateDropChanceID": 0,
+            "CrateDropTypeID": 89,
+            "MiscDropChanceID": 0,
+            "MiscDropTypeID": 135
+        },
+        "1350": {
+            "MobDropID": 1350,
+            "CrateDropChanceID": 0,
+            "CrateDropTypeID": 33,
+            "MiscDropChanceID": 0,
+            "MiscDropTypeID": 136
+        },
+        "1351": {
+            "MobDropID": 1351,
+            "CrateDropChanceID": 0,
+            "CrateDropTypeID": 63,
+            "MiscDropChanceID": 0,
+            "MiscDropTypeID": 136
+        },
+        "1360": {
+            "MobDropID": 1360,
+            "CrateDropChanceID": 0,
+            "CrateDropTypeID": 34,
+            "MiscDropChanceID": 0,
+            "MiscDropTypeID": 137
+        },
+        "1361": {
+            "MobDropID": 1361,
+            "CrateDropChanceID": 0,
+            "CrateDropTypeID": 90,
+            "MiscDropChanceID": 0,
+            "MiscDropTypeID": 137
+        },
+        "1370": {
+            "MobDropID": 1370,
+            "CrateDropChanceID": 0,
+            "CrateDropTypeID": 64,
+            "MiscDropChanceID": 0,
+            "MiscDropTypeID": 138
+        },
+        "1371": {
+            "MobDropID": 1371,
+            "CrateDropChanceID": 0,
+            "CrateDropTypeID": 90,
+            "MiscDropChanceID": 0,
+            "MiscDropTypeID": 138
+        },
+        "1380": {
+            "MobDropID": 1380,
+            "CrateDropChanceID": 0,
+            "CrateDropTypeID": 34,
+            "MiscDropChanceID": 0,
+            "MiscDropTypeID": 139
+        },
+        "1381": {
+            "MobDropID": 1381,
+            "CrateDropChanceID": 0,
+            "CrateDropTypeID": 64,
+            "MiscDropChanceID": 0,
+            "MiscDropTypeID": 139
+        },
+        "1382": {
+            "MobDropID": 1382,
+            "CrateDropChanceID": 0,
+            "CrateDropTypeID": 90,
+            "MiscDropChanceID": 0,
+            "MiscDropTypeID": 139
+        },
+        "1390": {
+            "MobDropID": 1390,
+            "CrateDropChanceID": 0,
+            "CrateDropTypeID": 34,
+            "MiscDropChanceID": 0,
+            "MiscDropTypeID": 140
+        },
+        "1391": {
+            "MobDropID": 1391,
+            "CrateDropChanceID": 0,
+            "CrateDropTypeID": 64,
+            "MiscDropChanceID": 0,
+            "MiscDropTypeID": 140
+        },
+        "1400": {
+            "MobDropID": 1400,
+            "CrateDropChanceID": 0,
+            "CrateDropTypeID": 35,
+            "MiscDropChanceID": 0,
+            "MiscDropTypeID": 141
+        },
+        "1401": {
+            "MobDropID": 1401,
+            "CrateDropChanceID": 0,
+            "CrateDropTypeID": 65,
+            "MiscDropChanceID": 0,
+            "MiscDropTypeID": 141
+        },
+        "1402": {
+            "MobDropID": 1402,
+            "CrateDropChanceID": 0,
+            "CrateDropTypeID": 91,
+            "MiscDropChanceID": 0,
+            "MiscDropTypeID": 141
+        },
+        "1410": {
+            "MobDropID": 1410,
+            "CrateDropChanceID": 0,
+            "CrateDropTypeID": 65,
+            "MiscDropChanceID": 0,
+            "MiscDropTypeID": 142
+        },
+        "1411": {
+            "MobDropID": 1411,
+            "CrateDropChanceID": 0,
+            "CrateDropTypeID": 91,
+            "MiscDropChanceID": 0,
+            "MiscDropTypeID": 142
+        },
+        "1420": {
+            "MobDropID": 1420,
+            "CrateDropChanceID": 0,
+            "CrateDropTypeID": 35,
+            "MiscDropChanceID": 0,
+            "MiscDropTypeID": 143
+        },
+        "1421": {
+            "MobDropID": 1421,
+            "CrateDropChanceID": 0,
+            "CrateDropTypeID": 65,
+            "MiscDropChanceID": 0,
+            "MiscDropTypeID": 143
+        },
+        "1422": {
+            "MobDropID": 1422,
+            "CrateDropChanceID": 0,
+            "CrateDropTypeID": 91,
+            "MiscDropChanceID": 0,
+            "MiscDropTypeID": 143
+        },
+        "1430": {
+            "MobDropID": 1430,
+            "CrateDropChanceID": 0,
+            "CrateDropTypeID": 35,
+            "MiscDropChanceID": 0,
+            "MiscDropTypeID": 144
+        },
+        "1431": {
+            "MobDropID": 1431,
+            "CrateDropChanceID": 0,
+            "CrateDropTypeID": 65,
+            "MiscDropChanceID": 0,
+            "MiscDropTypeID": 144
+        },
+        "1432": {
+            "MobDropID": 1432,
+            "CrateDropChanceID": 0,
+            "CrateDropTypeID": 91,
+            "MiscDropChanceID": 0,
+            "MiscDropTypeID": 144
+        },
+        "1440": {
+            "MobDropID": 1440,
+            "CrateDropChanceID": 1,
+            "CrateDropTypeID": 92,
+            "MiscDropChanceID": 0,
+            "MiscDropTypeID": 0
+        },
+        "1441": {
+            "MobDropID": 1441,
+            "CrateDropChanceID": 1,
+            "CrateDropTypeID": 93,
+            "MiscDropChanceID": 0,
+            "MiscDropTypeID": 0
+        },
+        "1442": {
+            "MobDropID": 1442,
+            "CrateDropChanceID": 1,
+            "CrateDropTypeID": 95,
+            "MiscDropChanceID": 0,
+            "MiscDropTypeID": 145
+        },
+        "1443": {
+            "MobDropID": 1443,
+            "CrateDropChanceID": 1,
+            "CrateDropTypeID": 96,
+            "MiscDropChanceID": 0,
+            "MiscDropTypeID": 146
+        },
+        "1444": {
+            "MobDropID": 1444,
+            "CrateDropChanceID": 1,
+            "CrateDropTypeID": 97,
+            "MiscDropChanceID": 0,
+            "MiscDropTypeID": 147
+        },
+        "1445": {
+            "MobDropID": 1445,
+            "CrateDropChanceID": 1,
+            "CrateDropTypeID": 98,
+            "MiscDropChanceID": 0,
+            "MiscDropTypeID": 148
+        },
+        "1446": {
+            "MobDropID": 1446,
             "CrateDropChanceID": 2,
             "CrateDropTypeID": 99,
             "MiscDropChanceID": 1,
-            "MiscDropTypeID": 117
+            "MiscDropTypeID": 0
         },
-        "354": {
-            "MobDropID": 707,
+        "1447": {
+            "MobDropID": 1447,
             "CrateDropChanceID": 2,
             "CrateDropTypeID": 100,
             "MiscDropChanceID": 1,
-            "MiscDropTypeID": 117
+            "MiscDropTypeID": 0
         },
-        "355": {
-            "MobDropID": 708,
+        "1448": {
+            "MobDropID": 1448,
             "CrateDropChanceID": 2,
             "CrateDropTypeID": 101,
             "MiscDropChanceID": 1,
-            "MiscDropTypeID": 117
+            "MiscDropTypeID": 0
         }
     },
     "Events": {
         "0": {
             "EventID": 1,
-            "MobDropID": 706
+            "MobDropID": 1446
         },
         "1": {
             "EventID": 2,
-            "MobDropID": 707
+            "MobDropID": 1447
         },
         "2": {
             "EventID": 3,
-            "MobDropID": 708
+            "MobDropID": 1448
         }
     },
     "Mobs": {
         "0": {
             "MobID": 1,
-            "MobDropID": 12
+            "MobDropID": 110
         },
         "1": {
             "MobID": 2,
-            "MobDropID": 76
+            "MobDropID": 750
         },
         "2": {
             "MobID": 3,
-            "MobDropID": 32
+            "MobDropID": 310
         },
         "3": {
             "MobID": 4,
-            "MobDropID": 24
+            "MobDropID": 230
         },
         "4": {
             "MobID": 5,
-            "MobDropID": 20
+            "MobDropID": 190
         },
         "5": {
             "MobID": 6,
-            "MobDropID": 24
+            "MobDropID": 230
         },
         "6": {
             "MobID": 7,
-            "MobDropID": 4
+            "MobDropID": 30
         },
         "7": {
             "MobID": 8,
-            "MobDropID": 237
+            "MobDropID": 831
         },
         "8": {
             "MobID": 9,
-            "MobDropID": 84
+            "MobDropID": 830
         },
         "9": {
             "MobID": 10,
-            "MobDropID": 185
+            "MobDropID": 311
         },
         "10": {
             "MobID": 11,
-            "MobDropID": 32
+            "MobDropID": 310
         },
         "11": {
             "MobID": 12,
-            "MobDropID": 189
+            "MobDropID": 351
         },
         "12": {
             "MobID": 13,
-            "MobDropID": 193
+            "MobDropID": 391
         },
         "13": {
             "MobID": 14,
-            "MobDropID": 40
+            "MobDropID": 390
         },
         "14": {
             "MobID": 15,
-            "MobDropID": 44
+            "MobDropID": 430
         },
         "15": {
             "MobID": 17,
-            "MobDropID": 349
+            "MobDropID": 512
         },
         "16": {
             "MobID": 19,
-            "MobDropID": 8
+            "MobDropID": 70
         },
         "17": {
             "MobID": 20,
-            "MobDropID": 393
+            "MobDropID": 951
         },
         "18": {
             "MobID": 21,
-            "MobDropID": 385
+            "MobDropID": 872
         },
         "19": {
             "MobID": 22,
-            "MobDropID": 213
+            "MobDropID": 591
         },
         "20": {
             "MobID": 23,
-            "MobDropID": 205
+            "MobDropID": 511
         },
         "21": {
             "MobID": 24,
-            "MobDropID": 365
+            "MobDropID": 671
         },
         "22": {
             "MobID": 27,
-            "MobDropID": 381
+            "MobDropID": 832
         },
         "23": {
             "MobID": 28,
-            "MobDropID": 52
+            "MobDropID": 510
         },
         "24": {
             "MobID": 29,
-            "MobDropID": 108
+            "MobDropID": 1070
         },
         "25": {
             "MobID": 30,
-            "MobDropID": 229
+            "MobDropID": 751
         },
         "26": {
             "MobID": 31,
-            "MobDropID": 116
+            "MobDropID": 1150
         },
         "27": {
             "MobID": 33,
-            "MobDropID": 233
+            "MobDropID": 791
         },
         "28": {
             "MobID": 34,
-            "MobDropID": 241
+            "MobDropID": 871
         },
         "29": {
             "MobID": 35,
-            "MobDropID": 389
+            "MobDropID": 912
         },
         "30": {
             "MobID": 37,
-            "MobDropID": 261
+            "MobDropID": 1071
         },
         "31": {
             "MobID": 38,
-            "MobDropID": 417
+            "MobDropID": 1191
         },
         "32": {
             "MobID": 40,
-            "MobDropID": 96
+            "MobDropID": 950
         },
         "33": {
             "MobID": 42,
-            "MobDropID": 201
+            "MobDropID": 471
         },
         "34": {
             "MobID": 43,
-            "MobDropID": 257
+            "MobDropID": 1031
         },
         "35": {
             "MobID": 44,
-            "MobDropID": 225
+            "MobDropID": 710
         },
         "36": {
             "MobID": 45,
-            "MobDropID": 124
+            "MobDropID": 1230
         },
         "37": {
             "MobID": 46,
-            "MobDropID": 72
+            "MobDropID": 750
         },
         "38": {
             "MobID": 47,
-            "MobDropID": 128
+            "MobDropID": 1270
         },
         "39": {
             "MobID": 48,
-            "MobDropID": 136
+            "MobDropID": 1350
         },
         "40": {
             "MobID": 49,
-            "MobDropID": 289
+            "MobDropID": 1351
         },
         "41": {
             "MobID": 50,
-            "MobDropID": 429
+            "MobDropID": 1312
         },
         "42": {
             "MobID": 52,
-            "MobDropID": 140
+            "MobDropID": 1390
         },
         "43": {
             "MobID": 55,
-            "MobDropID": 1
+            "MobDropID": 10
         },
         "44": {
             "MobID": 60,
-            "MobDropID": 5
+            "MobDropID": 50
         },
         "45": {
             "MobID": 61,
-            "MobDropID": 5
+            "MobDropID": 50
         },
         "46": {
             "MobID": 64,
-            "MobDropID": 5
+            "MobDropID": 50
         },
         "47": {
             "MobID": 65,
-            "MobDropID": 9
+            "MobDropID": 90
         },
         "48": {
             "MobID": 68,
-            "MobDropID": 9
+            "MobDropID": 90
         },
         "49": {
             "MobID": 70,
-            "MobDropID": 9
+            "MobDropID": 90
         },
         "50": {
             "MobID": 71,
-            "MobDropID": 9
+            "MobDropID": 90
         },
         "51": {
             "MobID": 74,
-            "MobDropID": 13
+            "MobDropID": 130
         },
         "52": {
             "MobID": 75,
-            "MobDropID": 13
+            "MobDropID": 130
         },
         "53": {
             "MobID": 77,
-            "MobDropID": 9
+            "MobDropID": 90
         },
         "54": {
             "MobID": 273,
-            "MobDropID": 9
+            "MobDropID": 80
         },
         "55": {
             "MobID": 82,
-            "MobDropID": 13
+            "MobDropID": 130
         },
         "56": {
             "MobID": 83,
-            "MobDropID": 5
+            "MobDropID": 50
         },
         "57": {
             "MobID": 84,
-            "MobDropID": 17
+            "MobDropID": 170
         },
         "58": {
             "MobID": 85,
-            "MobDropID": 17
+            "MobDropID": 170
         },
         "59": {
             "MobID": 86,
-            "MobDropID": 17
+            "MobDropID": 170
         },
         "60": {
             "MobID": 88,
-            "MobDropID": 21
+            "MobDropID": 210
         },
         "61": {
             "MobID": 90,
-            "MobDropID": 21
+            "MobDropID": 210
         },
         "62": {
             "MobID": 93,
-            "MobDropID": 21
+            "MobDropID": 210
         },
         "63": {
             "MobID": 94,
-            "MobDropID": 178
+            "MobDropID": 251
         },
         "64": {
             "MobID": 96,
-            "MobDropID": 178
+            "MobDropID": 251
         },
         "65": {
             "MobID": 97,
-            "MobDropID": 25
+            "MobDropID": 250
         },
         "66": {
             "MobID": 98,
-            "MobDropID": 178
+            "MobDropID": 251
         },
         "67": {
             "MobID": 104,
-            "MobDropID": 29
+            "MobDropID": 290
         },
         "68": {
             "MobID": 107,
-            "MobDropID": 29
+            "MobDropID": 290
         },
         "69": {
             "MobID": 108,
-            "MobDropID": 182
+            "MobDropID": 291
         },
         "70": {
             "MobID": 109,
-            "MobDropID": 33
+            "MobDropID": 330
         },
         "71": {
             "MobID": 114,
-            "MobDropID": 186
+            "MobDropID": 331
         },
         "72": {
             "MobID": 117,
-            "MobDropID": 37
+            "MobDropID": 370
         },
         "73": {
             "MobID": 118,
-            "MobDropID": 37
+            "MobDropID": 370
         },
         "74": {
             "MobID": 119,
-            "MobDropID": 37
+            "MobDropID": 370
         },
         "75": {
             "MobID": 121,
-            "MobDropID": 190
+            "MobDropID": 371
         },
         "76": {
             "MobID": 122,
-            "MobDropID": 37
+            "MobDropID": 370
         },
         "77": {
             "MobID": 125,
-            "MobDropID": 194
+            "MobDropID": 411
         },
         "78": {
             "MobID": 127,
-            "MobDropID": 338
+            "MobDropID": 412
         },
         "79": {
             "MobID": 129,
-            "MobDropID": 41
+            "MobDropID": 410
         },
         "80": {
             "MobID": 130,
-            "MobDropID": 194
+            "MobDropID": 411
         },
         "81": {
             "MobID": 133,
-            "MobDropID": 198
+            "MobDropID": 451
         },
         "82": {
             "MobID": 134,
-            "MobDropID": 342
+            "MobDropID": 452
         },
         "83": {
             "MobID": 136,
-            "MobDropID": 45
+            "MobDropID": 450
         },
         "84": {
             "MobID": 139,
-            "MobDropID": 202
+            "MobDropID": 491
         },
         "85": {
             "MobID": 142,
-            "MobDropID": 49
+            "MobDropID": 490
         },
         "86": {
             "MobID": 143,
-            "MobDropID": 350
+            "MobDropID": 531
         },
         "87": {
             "MobID": 145,
-            "MobDropID": 206
+            "MobDropID": 530
         },
         "88": {
             "MobID": 146,
-            "MobDropID": 354
+            "MobDropID": 572
         },
         "89": {
             "MobID": 156,
-            "MobDropID": 214
+            "MobDropID": 610
         },
         "90": {
             "MobID": 161,
-            "MobDropID": 206
+            "MobDropID": 530
         },
         "91": {
             "MobID": 163,
-            "MobDropID": 57
+            "MobDropID": 570
         },
         "92": {
             "MobID": 164,
-            "MobDropID": 210
+            "MobDropID": 571
         },
         "93": {
             "MobID": 165,
-            "MobDropID": 354
+            "MobDropID": 572
         },
         "94": {
             "MobID": 167,
-            "MobDropID": 362
+            "MobDropID": 652
         },
         "95": {
             "MobID": 363,
-            "MobDropID": 65
+            "MobDropID": 640
         },
         "96": {
             "MobID": 170,
-            "MobDropID": 218
+            "MobDropID": 651
         },
         "97": {
             "MobID": 171,
-            "MobDropID": 366
+            "MobDropID": 692
         },
         "98": {
             "MobID": 174,
-            "MobDropID": 214
+            "MobDropID": 610
         },
         "99": {
             "MobID": 178,
-            "MobDropID": 370
+            "MobDropID": 732
         },
         "100": {
             "MobID": 180,
-            "MobDropID": 73
+            "MobDropID": 730
         },
         "101": {
             "MobID": 182,
-            "MobDropID": 65
+            "MobDropID": 650
         },
         "102": {
             "MobID": 184,
-            "MobDropID": 222
+            "MobDropID": 691
         },
         "103": {
             "MobID": 187,
-            "MobDropID": 374
+            "MobDropID": 772
         },
         "104": {
             "MobID": 189,
-            "MobDropID": 77
+            "MobDropID": 770
         },
         "105": {
             "MobID": 190,
-            "MobDropID": 378
+            "MobDropID": 812
         },
         "106": {
             "MobID": 191,
-            "MobDropID": 234
+            "MobDropID": 811
         },
         "107": {
             "MobID": 192,
-            "MobDropID": 234
+            "MobDropID": 811
         },
         "108": {
             "MobID": 193,
-            "MobDropID": 73
+            "MobDropID": 730
         },
         "109": {
             "MobID": 194,
-            "MobDropID": 226
+            "MobDropID": 731
         },
         "110": {
             "MobID": 196,
-            "MobDropID": 230
+            "MobDropID": 771
         },
         "111": {
             "MobID": 197,
-            "MobDropID": 230
+            "MobDropID": 771
         },
         "112": {
             "MobID": 200,
-            "MobDropID": 382
+            "MobDropID": 852
         },
         "113": {
             "MobID": 201,
-            "MobDropID": 238
+            "MobDropID": 851
         },
         "114": {
             "MobID": 202,
-            "MobDropID": 89
+            "MobDropID": 890
         },
         "115": {
             "MobID": 203,
-            "MobDropID": 89
+            "MobDropID": 890
         },
         "116": {
             "MobID": 204,
-            "MobDropID": 242
+            "MobDropID": 891
         },
         "117": {
             "MobID": 205,
-            "MobDropID": 386
+            "MobDropID": 892
         },
         "118": {
             "MobID": 206,
-            "MobDropID": 81
+            "MobDropID": 810
         },
         "119": {
             "MobID": 211,
-            "MobDropID": 85
+            "MobDropID": 850
         },
         "120": {
             "MobID": 215,
-            "MobDropID": 93
+            "MobDropID": 930
         },
         "121": {
             "MobID": 217,
-            "MobDropID": 242
+            "MobDropID": 891
         },
         "122": {
             "MobID": 218,
-            "MobDropID": 386
+            "MobDropID": 892
         },
         "123": {
             "MobID": 220,
-            "MobDropID": 97
+            "MobDropID": 970
         },
         "124": {
             "MobID": 225,
-            "MobDropID": 246
+            "MobDropID": 931
         },
         "125": {
             "MobID": 227,
-            "MobDropID": 398
+            "MobDropID": 1011
         },
         "126": {
             "MobID": 228,
-            "MobDropID": 101
+            "MobDropID": 1010
         },
         "127": {
             "MobID": 232,
-            "MobDropID": 105
+            "MobDropID": 1050
         },
         "128": {
             "MobID": 235,
-            "MobDropID": 97
+            "MobDropID": 970
         },
         "129": {
             "MobID": 240,
-            "MobDropID": 105
+            "MobDropID": 1050
         },
         "130": {
             "MobID": 241,
-            "MobDropID": 398
+            "MobDropID": 1011
         },
         "131": {
             "MobID": 244,
-            "MobDropID": 117
+            "MobDropID": 1170
         },
         "132": {
             "MobID": 249,
-            "MobDropID": 6
+            "MobDropID": 40
         },
         "133": {
             "MobID": 59,
-            "MobDropID": 6
+            "MobDropID": 50
         },
         "134": {
             "MobID": 255,
-            "MobDropID": 6
+            "MobDropID": 40
         },
         "135": {
             "MobID": 256,
-            "MobDropID": 6
+            "MobDropID": 40
         },
         "136": {
             "MobID": 257,
-            "MobDropID": 6
+            "MobDropID": 40
         },
         "137": {
             "MobID": 263,
-            "MobDropID": 10
+            "MobDropID": 80
         },
         "138": {
             "MobID": 264,
-            "MobDropID": 10
+            "MobDropID": 80
         },
         "139": {
             "MobID": 270,
-            "MobDropID": 14
+            "MobDropID": 120
         },
         "140": {
             "MobID": 274,
-            "MobDropID": 14
+            "MobDropID": 120
         },
         "141": {
             "MobID": 275,
-            "MobDropID": 14
+            "MobDropID": 120
         },
         "142": {
             "MobID": 279,
-            "MobDropID": 18
+            "MobDropID": 160
         },
         "143": {
             "MobID": 281,
-            "MobDropID": 2
+            "MobDropID": 0
         },
         "144": {
             "MobID": 282,
-            "MobDropID": 22
+            "MobDropID": 200
         },
         "145": {
             "MobID": 283,
-            "MobDropID": 22
+            "MobDropID": 200
         },
         "146": {
             "MobID": 285,
-            "MobDropID": 22
+            "MobDropID": 200
         },
         "147": {
             "MobID": 286,
-            "MobDropID": 22
+            "MobDropID": 200
         },
         "148": {
             "MobID": 287,
-            "MobDropID": 22
+            "MobDropID": 200
         },
         "149": {
             "MobID": 289,
-            "MobDropID": 26
+            "MobDropID": 240
         },
         "150": {
             "MobID": 293,
-            "MobDropID": 26
+            "MobDropID": 240
         },
         "151": {
             "MobID": 297,
-            "MobDropID": 183
+            "MobDropID": 281
         },
         "152": {
             "MobID": 299,
-            "MobDropID": 183
+            "MobDropID": 281
         },
         "153": {
             "MobID": 300,
-            "MobDropID": 30
+            "MobDropID": 280
         },
         "154": {
             "MobID": 302,
-            "MobDropID": 183
+            "MobDropID": 281
         },
         "155": {
             "MobID": 303,
-            "MobDropID": 34
+            "MobDropID": 320
         },
         "156": {
             "MobID": 304,
-            "MobDropID": 187
+            "MobDropID": 321
         },
         "157": {
             "MobID": 305,
-            "MobDropID": 34
+            "MobDropID": 320
         },
         "158": {
             "MobID": 306,
-            "MobDropID": 34
+            "MobDropID": 320
         },
         "159": {
             "MobID": 307,
-            "MobDropID": 10
+            "MobDropID": 80
         },
         "160": {
             "MobID": 309,
-            "MobDropID": 187
+            "MobDropID": 321
         },
         "161": {
             "MobID": 310,
-            "MobDropID": 10
+            "MobDropID": 80
         },
         "162": {
             "MobID": 314,
-            "MobDropID": 191
+            "MobDropID": 361
         },
         "163": {
             "MobID": 316,
-            "MobDropID": 38
+            "MobDropID": 360
         },
         "164": {
             "MobID": 317,
-            "MobDropID": 191
+            "MobDropID": 361
         },
         "165": {
             "MobID": 318,
-            "MobDropID": 42
+            "MobDropID": 400
         },
         "166": {
             "MobID": 320,
-            "MobDropID": 339
+            "MobDropID": 402
         },
         "167": {
             "MobID": 322,
-            "MobDropID": 42
+            "MobDropID": 400
         },
         "168": {
             "MobID": 324,
-            "MobDropID": 195
+            "MobDropID": 401
         },
         "169": {
             "MobID": 325,
-            "MobDropID": 46
+            "MobDropID": 440
         },
         "170": {
             "MobID": 326,
-            "MobDropID": 343
+            "MobDropID": 442
         },
         "171": {
             "MobID": 329,
-            "MobDropID": 199
+            "MobDropID": 441
         },
         "172": {
             "MobID": 333,
-            "MobDropID": 203
+            "MobDropID": 481
         },
         "173": {
             "MobID": 334,
-            "MobDropID": 50
+            "MobDropID": 480
         },
         "174": {
             "MobID": 335,
-            "MobDropID": 203
+            "MobDropID": 481
         },
         "175": {
             "MobID": 338,
-            "MobDropID": 54
+            "MobDropID": 520
         },
         "176": {
             "MobID": 339,
-            "MobDropID": 207
+            "MobDropID": 521
         },
         "177": {
             "MobID": 341,
-            "MobDropID": 58
+            "MobDropID": 560
         },
         "178": {
             "MobID": 342,
-            "MobDropID": 58
+            "MobDropID": 560
         },
         "179": {
             "MobID": 348,
-            "MobDropID": 62
+            "MobDropID": 600
         },
         "180": {
             "MobID": 349,
-            "MobDropID": 62
+            "MobDropID": 600
         },
         "181": {
             "MobID": 354,
-            "MobDropID": 54
+            "MobDropID": 520
         },
         "182": {
             "MobID": 356,
-            "MobDropID": 54
+            "MobDropID": 520
         },
         "183": {
             "MobID": 359,
-            "MobDropID": 355
+            "MobDropID": 562
         },
         "184": {
             "MobID": 360,
-            "MobDropID": 211
+            "MobDropID": 561
         },
         "185": {
             "MobID": 362,
-            "MobDropID": 66
+            "MobDropID": 640
         },
         "186": {
             "MobID": 364,
-            "MobDropID": 219
+            "MobDropID": 641
         },
         "187": {
             "MobID": 365,
-            "MobDropID": 367
+            "MobDropID": 681
         },
         "188": {
             "MobID": 366,
-            "MobDropID": 70
+            "MobDropID": 680
         },
         "189": {
             "MobID": 369,
-            "MobDropID": 359
+            "MobDropID": 601
         },
         "190": {
             "MobID": 370,
-            "MobDropID": 359
+            "MobDropID": 601
         },
         "191": {
             "MobID": 371,
-            "MobDropID": 371
+            "MobDropID": 722
         },
         "192": {
             "MobID": 373,
-            "MobDropID": 74
+            "MobDropID": 720
         },
         "193": {
             "MobID": 375,
-            "MobDropID": 219
+            "MobDropID": 641
         },
         "194": {
             "MobID": 377,
-            "MobDropID": 363
+            "MobDropID": 642
         },
         "195": {
             "MobID": 379,
-            "MobDropID": 70
+            "MobDropID": 680
         },
         "196": {
             "MobID": 380,
-            "MobDropID": 70
+            "MobDropID": 680
         },
         "197": {
             "MobID": 381,
-            "MobDropID": 375
+            "MobDropID": 762
         },
         "198": {
             "MobID": 382,
-            "MobDropID": 78
+            "MobDropID": 760
         },
         "199": {
             "MobID": 383,
-            "MobDropID": 78
+            "MobDropID": 760
         },
         "200": {
             "MobID": 385,
-            "MobDropID": 235
+            "MobDropID": 801
         },
         "201": {
             "MobID": 386,
-            "MobDropID": 235
+            "MobDropID": 801
         },
         "202": {
             "MobID": 388,
-            "MobDropID": 227
+            "MobDropID": 721
         },
         "203": {
             "MobID": 389,
-            "MobDropID": 227
+            "MobDropID": 721
         },
         "204": {
             "MobID": 390,
-            "MobDropID": 231
+            "MobDropID": 761
         },
         "205": {
             "MobID": 391,
-            "MobDropID": 231
+            "MobDropID": 761
         },
         "206": {
             "MobID": 392,
-            "MobDropID": 375
+            "MobDropID": 762
         },
         "207": {
             "MobID": 393,
-            "MobDropID": 383
+            "MobDropID": 842
         },
         "208": {
             "MobID": 394,
-            "MobDropID": 383
+            "MobDropID": 842
         },
         "209": {
             "MobID": 397,
-            "MobDropID": 90
+            "MobDropID": 880
         },
         "210": {
             "MobID": 398,
-            "MobDropID": 243
+            "MobDropID": 881
         },
         "211": {
             "MobID": 399,
-            "MobDropID": 387
+            "MobDropID": 882
         },
         "212": {
             "MobID": 401,
-            "MobDropID": 82
+            "MobDropID": 800
         },
         "213": {
             "MobID": 402,
-            "MobDropID": 379
+            "MobDropID": 802
         },
         "214": {
             "MobID": 403,
-            "MobDropID": 239
+            "MobDropID": 841
         },
         "215": {
             "MobID": 404,
-            "MobDropID": 86
+            "MobDropID": 840
         },
         "216": {
             "MobID": 406,
-            "MobDropID": 391
+            "MobDropID": 922
         },
         "217": {
             "MobID": 407,
-            "MobDropID": 391
+            "MobDropID": 922
         },
         "218": {
             "MobID": 408,
-            "MobDropID": 94
+            "MobDropID": 920
         },
         "219": {
             "MobID": 410,
-            "MobDropID": 94
+            "MobDropID": 920
         },
         "220": {
             "MobID": 411,
-            "MobDropID": 243
+            "MobDropID": 881
         },
         "221": {
             "MobID": 413,
-            "MobDropID": 387
+            "MobDropID": 882
         },
         "222": {
             "MobID": 414,
-            "MobDropID": 98
+            "MobDropID": 960
         },
         "223": {
             "MobID": 221,
-            "MobDropID": 395
+            "MobDropID": 971
         },
         "224": {
             "MobID": 416,
-            "MobDropID": 395
+            "MobDropID": 962
         },
         "225": {
             "MobID": 417,
-            "MobDropID": 247
+            "MobDropID": 921
         },
         "226": {
             "MobID": 418,
-            "MobDropID": 94
+            "MobDropID": 920
         },
         "227": {
             "MobID": 420,
-            "MobDropID": 255
+            "MobDropID": 1001
         },
         "228": {
             "MobID": 422,
-            "MobDropID": 102
+            "MobDropID": 1000
         },
         "229": {
             "MobID": 427,
-            "MobDropID": 403
+            "MobDropID": 1042
         },
         "230": {
             "MobID": 428,
-            "MobDropID": 259
+            "MobDropID": 1041
         },
         "231": {
             "MobID": 430,
-            "MobDropID": 251
+            "MobDropID": 961
         },
         "232": {
             "MobID": 431,
-            "MobDropID": 251
+            "MobDropID": 961
         },
         "233": {
             "MobID": 432,
-            "MobDropID": 403
+            "MobDropID": 1042
         },
         "234": {
             "MobID": 433,
-            "MobDropID": 259
+            "MobDropID": 1041
         },
         "235": {
             "MobID": 434,
-            "MobDropID": 106
+            "MobDropID": 1040
         },
         "236": {
             "MobID": 436,
-            "MobDropID": 255
+            "MobDropID": 1001
         },
         "237": {
             "MobID": 437,
-            "MobDropID": 102
+            "MobDropID": 1000
         },
         "238": {
             "MobID": 438,
-            "MobDropID": 118
+            "MobDropID": 1160
         },
         "239": {
             "MobID": 439,
-            "MobDropID": 126
+            "MobDropID": 1240
         },
         "240": {
             "MobID": 440,
-            "MobDropID": 114
+            "MobDropID": 1120
         },
         "241": {
             "MobID": 443,
-            "MobDropID": 3
+            "MobDropID": 20
         },
         "242": {
             "MobID": 447,
-            "MobDropID": 7
+            "MobDropID": 60
         },
         "243": {
             "MobID": 448,
-            "MobDropID": 7
+            "MobDropID": 60
         },
         "244": {
             "MobID": 449,
-            "MobDropID": 7
+            "MobDropID": 60
         },
         "245": {
             "MobID": 450,
-            "MobDropID": 7
+            "MobDropID": 60
         },
         "246": {
             "MobID": 451,
-            "MobDropID": 7
+            "MobDropID": 60
         },
         "247": {
             "MobID": 452,
-            "MobDropID": 7
+            "MobDropID": 60
         },
         "248": {
             "MobID": 453,
-            "MobDropID": 11
+            "MobDropID": 100
         },
         "249": {
             "MobID": 454,
-            "MobDropID": 699
+            "MobDropID": 1440
         },
         "250": {
             "MobID": 456,
-            "MobDropID": 11
+            "MobDropID": 100
         },
         "251": {
             "MobID": 457,
-            "MobDropID": 11
+            "MobDropID": 100
         },
         "252": {
             "MobID": 458,
-            "MobDropID": 11
+            "MobDropID": 100
         },
         "253": {
             "MobID": 459,
-            "MobDropID": 11
+            "MobDropID": 100
         },
         "254": {
             "MobID": 461,
-            "MobDropID": 700
+            "MobDropID": 1441
         },
         "255": {
             "MobID": 462,
-            "MobDropID": 15
+            "MobDropID": 140
         },
         "256": {
             "MobID": 463,
-            "MobDropID": 15
+            "MobDropID": 140
         },
         "257": {
             "MobID": 464,
-            "MobDropID": 15
+            "MobDropID": 140
         },
         "258": {
             "MobID": 465,
-            "MobDropID": 11
+            "MobDropID": 100
         },
         "259": {
             "MobID": 475,
-            "MobDropID": 3
+            "MobDropID": 20
         },
         "260": {
             "MobID": 477,
-            "MobDropID": 23
+            "MobDropID": 220
         },
         "261": {
             "MobID": 478,
-            "MobDropID": 23
+            "MobDropID": 220
         },
         "262": {
             "MobID": 479,
-            "MobDropID": 23
+            "MobDropID": 220
         },
         "263": {
             "MobID": 480,
-            "MobDropID": 23
+            "MobDropID": 220
         },
         "264": {
             "MobID": 481,
-            "MobDropID": 23
+            "MobDropID": 220
         },
         "265": {
             "MobID": 482,
-            "MobDropID": 180
+            "MobDropID": 261
         },
         "266": {
             "MobID": 483,
-            "MobDropID": 27
+            "MobDropID": 260
         },
         "267": {
             "MobID": 484,
-            "MobDropID": 180
+            "MobDropID": 261
         },
         "268": {
             "MobID": 487,
-            "MobDropID": 27
+            "MobDropID": 260
         },
         "269": {
             "MobID": 491,
-            "MobDropID": 184
+            "MobDropID": 301
         },
         "270": {
             "MobID": 492,
-            "MobDropID": 31
+            "MobDropID": 300
         },
         "271": {
             "MobID": 493,
-            "MobDropID": 184
+            "MobDropID": 301
         },
         "272": {
             "MobID": 494,
-            "MobDropID": 31
+            "MobDropID": 300
         },
         "273": {
             "MobID": 495,
-            "MobDropID": 31
+            "MobDropID": 300
         },
         "274": {
             "MobID": 496,
-            "MobDropID": 184
+            "MobDropID": 301
         },
         "275": {
             "MobID": 497,
-            "MobDropID": 35
+            "MobDropID": 340
         },
         "276": {
             "MobID": 498,
-            "MobDropID": 188
+            "MobDropID": 341
         },
         "277": {
             "MobID": 499,
-            "MobDropID": 35
+            "MobDropID": 340
         },
         "278": {
             "MobID": 500,
-            "MobDropID": 35
+            "MobDropID": 340
         },
         "279": {
             "MobID": 503,
-            "MobDropID": 188
+            "MobDropID": 341
         },
         "280": {
             "MobID": 504,
-            "MobDropID": 11
+            "MobDropID": 100
         },
         "281": {
             "MobID": 509,
-            "MobDropID": 192
+            "MobDropID": 381
         },
         "282": {
             "MobID": 510,
-            "MobDropID": 39
+            "MobDropID": 380
         },
         "283": {
             "MobID": 511,
-            "MobDropID": 192
+            "MobDropID": 381
         },
         "284": {
             "MobID": 512,
-            "MobDropID": 43
+            "MobDropID": 420
         },
         "285": {
             "MobID": 513,
-            "MobDropID": 196
+            "MobDropID": 421
         },
         "286": {
             "MobID": 514,
-            "MobDropID": 340
+            "MobDropID": 422
         },
         "287": {
             "MobID": 515,
-            "MobDropID": 340
+            "MobDropID": 422
         },
         "288": {
             "MobID": 519,
-            "MobDropID": 47
+            "MobDropID": 460
         },
         "289": {
             "MobID": 520,
-            "MobDropID": 344
+            "MobDropID": 462
         },
         "290": {
             "MobID": 521,
-            "MobDropID": 200
+            "MobDropID": 461
         },
         "291": {
             "MobID": 524,
-            "MobDropID": 47
+            "MobDropID": 460
         },
         "292": {
             "MobID": 530,
-            "MobDropID": 51
+            "MobDropID": 500
         },
         "293": {
             "MobID": 531,
-            "MobDropID": 352
+            "MobDropID": 542
         },
         "294": {
             "MobID": 532,
-            "MobDropID": 55
+            "MobDropID": 540
         },
         "295": {
             "MobID": 533,
-            "MobDropID": 208
+            "MobDropID": 541
         },
         "296": {
             "MobID": 534,
-            "MobDropID": 356
+            "MobDropID": 582
         },
         "297": {
             "MobID": 535,
-            "MobDropID": 59
+            "MobDropID": 580
         },
         "298": {
             "MobID": 536,
-            "MobDropID": 59
+            "MobDropID": 580
         },
         "299": {
             "MobID": 542,
-            "MobDropID": 63
+            "MobDropID": 620
         },
         "300": {
             "MobID": 543,
-            "MobDropID": 63
+            "MobDropID": 620
         },
         "301": {
             "MobID": 544,
-            "MobDropID": 216
+            "MobDropID": 621
         },
         "302": {
             "MobID": 548,
-            "MobDropID": 55
+            "MobDropID": 540
         },
         "303": {
             "MobID": 549,
-            "MobDropID": 208
+            "MobDropID": 541
         },
         "304": {
             "MobID": 550,
-            "MobDropID": 55
+            "MobDropID": 540
         },
         "305": {
             "MobID": 551,
-            "MobDropID": 59
+            "MobDropID": 580
         },
         "306": {
             "MobID": 552,
-            "MobDropID": 212
+            "MobDropID": 581
         },
         "307": {
             "MobID": 553,
-            "MobDropID": 356
+            "MobDropID": 582
         },
         "308": {
             "MobID": 554,
-            "MobDropID": 212
+            "MobDropID": 581
         },
         "309": {
             "MobID": 555,
-            "MobDropID": 364
+            "MobDropID": 662
         },
         "310": {
             "MobID": 559,
-            "MobDropID": 368
+            "MobDropID": 702
         },
         "311": {
             "MobID": 562,
-            "MobDropID": 216
+            "MobDropID": 621
         },
         "312": {
             "MobID": 563,
-            "MobDropID": 360
+            "MobDropID": 622
         },
         "313": {
             "MobID": 564,
-            "MobDropID": 360
+            "MobDropID": 622
         },
         "314": {
             "MobID": 565,
-            "MobDropID": 372
+            "MobDropID": 742
         },
         "315": {
             "MobID": 566,
-            "MobDropID": 372
+            "MobDropID": 742
         },
         "316": {
             "MobID": 567,
-            "MobDropID": 75
+            "MobDropID": 740
         },
         "317": {
             "MobID": 568,
-            "MobDropID": 75
+            "MobDropID": 740
         },
         "318": {
             "MobID": 569,
-            "MobDropID": 220
+            "MobDropID": 661
         },
         "319": {
             "MobID": 570,
-            "MobDropID": 67
+            "MobDropID": 660
         },
         "320": {
             "MobID": 571,
-            "MobDropID": 364
+            "MobDropID": 662
         },
         "321": {
             "MobID": 572,
-            "MobDropID": 224
+            "MobDropID": 701
         },
         "322": {
             "MobID": 573,
-            "MobDropID": 71
+            "MobDropID": 700
         },
         "323": {
             "MobID": 574,
-            "MobDropID": 71
+            "MobDropID": 700
         },
         "324": {
             "MobID": 575,
-            "MobDropID": 376
+            "MobDropID": 782
         },
         "325": {
             "MobID": 576,
-            "MobDropID": 79
+            "MobDropID": 780
         },
         "326": {
             "MobID": 577,
-            "MobDropID": 79
+            "MobDropID": 780
         },
         "327": {
             "MobID": 579,
-            "MobDropID": 236
+            "MobDropID": 821
         },
         "328": {
             "MobID": 581,
-            "MobDropID": 75
+            "MobDropID": 740
         },
         "329": {
             "MobID": 582,
-            "MobDropID": 228
+            "MobDropID": 741
         },
         "330": {
             "MobID": 583,
-            "MobDropID": 228
+            "MobDropID": 741
         },
         "331": {
             "MobID": 584,
-            "MobDropID": 232
+            "MobDropID": 781
         },
         "332": {
             "MobID": 585,
-            "MobDropID": 232
+            "MobDropID": 781
         },
         "333": {
             "MobID": 586,
-            "MobDropID": 376
+            "MobDropID": 782
         },
         "334": {
             "MobID": 589,
-            "MobDropID": 240
+            "MobDropID": 861
         },
         "335": {
             "MobID": 590,
-            "MobDropID": 91
+            "MobDropID": 900
         },
         "336": {
             "MobID": 591,
-            "MobDropID": 91
+            "MobDropID": 900
         },
         "337": {
             "MobID": 592,
-            "MobDropID": 244
+            "MobDropID": 901
         },
         "338": {
             "MobID": 593,
-            "MobDropID": 388
+            "MobDropID": 902
         },
         "339": {
             "MobID": 594,
-            "MobDropID": 83
+            "MobDropID": 820
         },
         "340": {
             "MobID": 595,
-            "MobDropID": 83
+            "MobDropID": 820
         },
         "341": {
             "MobID": 596,
-            "MobDropID": 380
+            "MobDropID": 822
         },
         "342": {
             "MobID": 597,
-            "MobDropID": 240
+            "MobDropID": 861
         },
         "343": {
             "MobID": 598,
-            "MobDropID": 87
+            "MobDropID": 860
         },
         "344": {
             "MobID": 599,
-            "MobDropID": 87
+            "MobDropID": 860
         },
         "345": {
             "MobID": 600,
-            "MobDropID": 392
+            "MobDropID": 942
         },
         "346": {
             "MobID": 601,
-            "MobDropID": 392
+            "MobDropID": 942
         },
         "347": {
             "MobID": 602,
-            "MobDropID": 95
+            "MobDropID": 940
         },
         "348": {
             "MobID": 603,
-            "MobDropID": 95
+            "MobDropID": 940
         },
         "349": {
             "MobID": 604,
-            "MobDropID": 95
+            "MobDropID": 940
         },
         "350": {
             "MobID": 605,
-            "MobDropID": 244
+            "MobDropID": 901
         },
         "351": {
             "MobID": 606,
-            "MobDropID": 388
+            "MobDropID": 902
         },
         "352": {
             "MobID": 607,
-            "MobDropID": 388
+            "MobDropID": 902
         },
         "353": {
             "MobID": 608,
-            "MobDropID": 99
+            "MobDropID": 980
         },
         "354": {
             "MobID": 609,
-            "MobDropID": 396
+            "MobDropID": 982
         },
         "355": {
             "MobID": 610,
-            "MobDropID": 396
+            "MobDropID": 982
         },
         "356": {
             "MobID": 611,
-            "MobDropID": 248
+            "MobDropID": 941
         },
         "357": {
             "MobID": 612,
-            "MobDropID": 95
+            "MobDropID": 940
         },
         "358": {
             "MobID": 613,
-            "MobDropID": 248
+            "MobDropID": 941
         },
         "359": {
             "MobID": 614,
-            "MobDropID": 256
+            "MobDropID": 1021
         },
         "360": {
             "MobID": 615,
-            "MobDropID": 400
+            "MobDropID": 1022
         },
         "361": {
             "MobID": 616,
-            "MobDropID": 103
+            "MobDropID": 1020
         },
         "362": {
             "MobID": 620,
-            "MobDropID": 107
+            "MobDropID": 1060
         },
         "363": {
             "MobID": 621,
-            "MobDropID": 404
+            "MobDropID": 1062
         },
         "364": {
             "MobID": 622,
-            "MobDropID": 260
+            "MobDropID": 1061
         },
         "365": {
             "MobID": 623,
-            "MobDropID": 99
+            "MobDropID": 980
         },
         "366": {
             "MobID": 624,
-            "MobDropID": 252
+            "MobDropID": 981
         },
         "367": {
             "MobID": 625,
-            "MobDropID": 252
+            "MobDropID": 981
         },
         "368": {
             "MobID": 626,
-            "MobDropID": 404
+            "MobDropID": 1062
         },
         "369": {
             "MobID": 627,
-            "MobDropID": 260
+            "MobDropID": 1061
         },
         "370": {
             "MobID": 628,
-            "MobDropID": 107
+            "MobDropID": 1060
         },
         "371": {
             "MobID": 629,
-            "MobDropID": 400
+            "MobDropID": 1022
         },
         "372": {
             "MobID": 630,
-            "MobDropID": 256
+            "MobDropID": 1021
         },
         "373": {
             "MobID": 631,
-            "MobDropID": 103
+            "MobDropID": 1020
         },
         "374": {
             "MobID": 632,
-            "MobDropID": 119
+            "MobDropID": 1180
         },
         "375": {
             "MobID": 633,
-            "MobDropID": 127
+            "MobDropID": 1260
         },
         "376": {
             "MobID": 634,
-            "MobDropID": 115
+            "MobDropID": 1140
         },
         "377": {
             "MobID": 1182,
-            "MobDropID": 10
+            "MobDropID": 80
         },
         "378": {
             "MobID": 1193,
-            "MobDropID": 185
+            "MobDropID": 311
         },
         "379": {
             "MobID": 1194,
-            "MobDropID": 40
+            "MobDropID": 390
         },
         "380": {
             "MobID": 1195,
-            "MobDropID": 40
+            "MobDropID": 390
         },
         "381": {
             "MobID": 1196,
-            "MobDropID": 345
+            "MobDropID": 472
         },
         "382": {
             "MobID": 1197,
-            "MobDropID": 24
+            "MobDropID": 230
         },
         "383": {
             "MobID": 1198,
-            "MobDropID": 20
+            "MobDropID": 190
         },
         "384": {
             "MobID": 1199,
-            "MobDropID": 197
+            "MobDropID": 431
         },
         "385": {
             "MobID": 1200,
-            "MobDropID": 193
+            "MobDropID": 391
         },
         "386": {
             "MobID": 1201,
-            "MobDropID": 36
+            "MobDropID": 350
         },
         "387": {
             "MobID": 1202,
-            "MobDropID": 32
+            "MobDropID": 310
         },
         "388": {
             "MobID": 1203,
-            "MobDropID": 28
+            "MobDropID": 270
         },
         "389": {
             "MobID": 1204,
-            "MobDropID": 209
+            "MobDropID": 550
         },
         "390": {
             "MobID": 106,
-            "MobDropID": 30
+            "MobDropID": 290
         },
         "391": {
             "MobID": 1268,
-            "MobDropID": 31
+            "MobDropID": 300
         },
         "392": {
             "MobID": 1313,
-            "MobDropID": 343
+            "MobDropID": 442
         },
         "393": {
             "MobID": 1316,
-            "MobDropID": 18
+            "MobDropID": 160
         },
         "394": {
             "MobID": 1317,
-            "MobDropID": 26
+            "MobDropID": 240
         },
         "395": {
             "MobID": 1340,
-            "MobDropID": 30
-        },
-        "395a": {
-            "MobID": 1342,
-            "MobDropID": 34
-        },
-        "396": {
-            "MobID": 1435,
-            "MobDropID": 38
-        },
-        "397": {
-            "MobID": 1455,
-            "MobDropID": 38
-        },
-        "398": {
-            "MobID": 1465,
-            "MobDropID": 191
-        },
-        "399": {
-            "MobID": 1466,
-            "MobDropID": 38
-        },
-        "400": {
-            "MobID": 1489,
-            "MobDropID": 18
-        },
-        "401": {
-            "MobID": 1627,
-            "MobDropID": 54
-        },
-        "402": {
-            "MobID": 1630,
-            "MobDropID": 217
-        },
-        "403": {
-            "MobID": 1633,
-            "MobDropID": 62
-        },
-        "404": {
-            "MobID": 1635,
-            "MobDropID": 70
-        },
-        "405": {
-            "MobID": 1638,
-            "MobDropID": 52
-        },
-        "406": {
-            "MobID": 1669,
-            "MobDropID": 347
-        },
-        "407": {
-            "MobID": 1673,
-            "MobDropID": 74
-        },
-        "408": {
-            "MobID": 1707,
-            "MobDropID": 221
-        },
-        "409": {
-            "MobID": 1710,
-            "MobDropID": 201
-        },
-        "410": {
-            "MobID": 1711,
-            "MobDropID": 48
-        },
-        "411": {
-            "MobID": 1712,
-            "MobDropID": 60
-        },
-        "412": {
-            "MobID": 1713,
-            "MobDropID": 64
-        },
-        "413": {
-            "MobID": 1716,
-            "MobDropID": 92
-        },
-        "414": {
-            "MobID": 1720,
-            "MobDropID": 80
-        },
-        "415": {
-            "MobID": 1721,
-            "MobDropID": 293
-        },
-        "416": {
-            "MobID": 1722,
-            "MobDropID": 346
-        },
-        "417": {
-            "MobID": 1724,
-            "MobDropID": 346
-        },
-        "418": {
-            "MobID": 1727,
-            "MobDropID": 366
-        },
-        "419": {
-            "MobID": 1809,
-            "MobDropID": 347
-        },
-        "420": {
-            "MobID": 1916,
-            "MobDropID": 361
-        },
-        "421": {
-            "MobID": 1917,
-            "MobDropID": 253
-        },
-        "422": {
-            "MobID": 1920,
-            "MobDropID": 112
-        },
-        "423": {
-            "MobID": 1921,
-            "MobDropID": 377
-        },
-        "424": {
-            "MobID": 1922,
-            "MobDropID": 100
-        },
-        "425": {
-            "MobID": 1923,
-            "MobDropID": 104
-        },
-        "426": {
-            "MobID": 1986,
-            "MobDropID": 267
-        },
-        "427": {
-            "MobID": 1988,
-            "MobDropID": 122
-        },
-        "428": {
-            "MobID": 1989,
-            "MobDropID": 134
-        },
-        "429": {
-            "MobID": 1990,
-            "MobDropID": 255
-        },
-        "430": {
-            "MobID": 1992,
-            "MobDropID": 283
-        },
-        "431": {
-            "MobID": 1998,
-            "MobDropID": 259
-        },
-        "432": {
-            "MobID": 2029,
-            "MobDropID": 279
-        },
-        "433": {
-            "MobID": 2030,
-            "MobDropID": 142
-        },
-        "434": {
-            "MobID": 2031,
-            "MobDropID": 285
-        },
-        "435": {
-            "MobID": 2032,
-            "MobDropID": 132
-        },
-        "436": {
-            "MobID": 2033,
-            "MobDropID": 429
-        },
-        "437": {
-            "MobID": 2034,
-            "MobDropID": 285
-        },
-        "438": {
-            "MobID": 2036,
-            "MobDropID": 281
-        },
-        "439": {
-            "MobID": 2037,
-            "MobDropID": 425
-        },
-        "440": {
-            "MobID": 2039,
-            "MobDropID": 109
-        },
-        "441": {
-            "MobID": 2044,
-            "MobDropID": 262
-        },
-        "442": {
-            "MobID": 2046,
-            "MobDropID": 406
-        },
-        "443": {
-            "MobID": 2048,
-            "MobDropID": 113
-        },
-        "444": {
-            "MobID": 2049,
-            "MobDropID": 410
-        },
-        "445": {
-            "MobID": 2051,
-            "MobDropID": 270
-        },
-        "446": {
-            "MobID": 2052,
-            "MobDropID": 270
-        },
-        "447": {
-            "MobID": 2053,
-            "MobDropID": 274
-        },
-        "448": {
-            "MobID": 2054,
-            "MobDropID": 121
-        },
-        "449": {
-            "MobID": 2058,
-            "MobDropID": 125
-        },
-        "450": {
-            "MobID": 2059,
-            "MobDropID": 282
-        },
-        "451": {
-            "MobID": 2060,
-            "MobDropID": 133
-        },
-        "452": {
-            "MobID": 2063,
-            "MobDropID": 430
-        },
-        "453": {
-            "MobID": 2066,
-            "MobDropID": 290
-        },
-        "454": {
-            "MobID": 2067,
-            "MobDropID": 434
-        },
-        "455": {
-            "MobID": 2071,
-            "MobDropID": 438
-        },
-        "456": {
-            "MobID": 2073,
-            "MobDropID": 263
-        },
-        "457": {
-            "MobID": 2041,
-            "MobDropID": 110
-        },
-        "458": {
-            "MobID": 2075,
-            "MobDropID": 407
-        },
-        "459": {
-            "MobID": 2078,
-            "MobDropID": 110
-        },
-        "460": {
-            "MobID": 2080,
-            "MobDropID": 271
-        },
-        "461": {
-            "MobID": 2082,
-            "MobDropID": 274
-        },
-        "462": {
-            "MobID": 2084,
-            "MobDropID": 275
-        },
-        "463": {
-            "MobID": 2085,
-            "MobDropID": 423
-        },
-        "464": {
-            "MobID": 2086,
-            "MobDropID": 126
-        },
-        "465": {
-            "MobID": 2087,
-            "MobDropID": 427
-        },
-        "466": {
-            "MobID": 2088,
-            "MobDropID": 287
-        },
-        "467": {
-            "MobID": 2089,
-            "MobDropID": 431
-        },
-        "468": {
-            "MobID": 2093,
-            "MobDropID": 435
-        },
-        "469": {
-            "MobID": 2095,
-            "MobDropID": 439
-        },
-        "470": {
-            "MobID": 2097,
-            "MobDropID": 111
-        },
-        "471": {
-            "MobID": 2098,
-            "MobDropID": 264
-        },
-        "472": {
-            "MobID": 2099,
-            "MobDropID": 111
-        },
-        "473": {
-            "MobID": 2100,
-            "MobDropID": 408
-        },
-        "474": {
-            "MobID": 2102,
-            "MobDropID": 264
-        },
-        "475": {
-            "MobID": 2103,
-            "MobDropID": 111
-        },
-        "476": {
-            "MobID": 2104,
-            "MobDropID": 408
-        },
-        "477": {
-            "MobID": 2105,
-            "MobDropID": 268
-        },
-        "478": {
-            "MobID": 2106,
-            "MobDropID": 115
-        },
-        "479": {
-            "MobID": 2107,
-            "MobDropID": 412
-        },
-        "480": {
-            "MobID": 2108,
-            "MobDropID": 119
-        },
-        "481": {
-            "MobID": 2109,
-            "MobDropID": 272
-        },
-        "482": {
-            "MobID": 2110,
-            "MobDropID": 272
-        },
-        "483": {
-            "MobID": 2111,
-            "MobDropID": 420
-        },
-        "484": {
-            "MobID": 2112,
-            "MobDropID": 123
-        },
-        "485": {
-            "MobID": 2113,
-            "MobDropID": 276
-        },
-        "486": {
-            "MobID": 2114,
             "MobDropID": 280
         },
+        "396": {
+            "MobID": 1342,
+            "MobDropID": 320
+        },
+        "397": {
+            "MobID": 1435,
+            "MobDropID": 360
+        },
+        "398": {
+            "MobID": 1455,
+            "MobDropID": 360
+        },
+        "399": {
+            "MobID": 1465,
+            "MobDropID": 361
+        },
+        "400": {
+            "MobID": 1466,
+            "MobDropID": 360
+        },
+        "401": {
+            "MobID": 1489,
+            "MobDropID": 160
+        },
+        "402": {
+            "MobID": 1627,
+            "MobDropID": 520
+        },
+        "403": {
+            "MobID": 1630,
+            "MobDropID": 631
+        },
+        "404": {
+            "MobID": 1633,
+            "MobDropID": 600
+        },
+        "405": {
+            "MobID": 1635,
+            "MobDropID": 680
+        },
+        "406": {
+            "MobID": 1638,
+            "MobDropID": 510
+        },
+        "407": {
+            "MobID": 1669,
+            "MobDropID": 482
+        },
+        "408": {
+            "MobID": 1673,
+            "MobDropID": 720
+        },
+        "409": {
+            "MobID": 1707,
+            "MobDropID": 670
+        },
+        "410": {
+            "MobID": 1710,
+            "MobDropID": 471
+        },
+        "411": {
+            "MobID": 1711,
+            "MobDropID": 470
+        },
+        "412": {
+            "MobID": 1712,
+            "MobDropID": 590
+        },
+        "413": {
+            "MobID": 1713,
+            "MobDropID": 630
+        },
+        "414": {
+            "MobID": 1716,
+            "MobDropID": 910
+        },
+        "415": {
+            "MobID": 1720,
+            "MobDropID": 790
+        },
+        "416": {
+            "MobID": 1721,
+            "MobDropID": 1391
+        },
+        "417": {
+            "MobID": 1722,
+            "MobDropID": 492
+        },
+        "418": {
+            "MobID": 1724,
+            "MobDropID": 492
+        },
+        "419": {
+            "MobID": 1727,
+            "MobDropID": 692
+        },
+        "420": {
+            "MobID": 1809,
+            "MobDropID": 482
+        },
+        "421": {
+            "MobID": 1916,
+            "MobDropID": 632
+        },
+        "422": {
+            "MobID": 1917,
+            "MobDropID": 991
+        },
+        "423": {
+            "MobID": 1920,
+            "MobDropID": 1110
+        },
+        "424": {
+            "MobID": 1921,
+            "MobDropID": 951
+        },
+        "425": {
+            "MobID": 1922,
+            "MobDropID": 990
+        },
+        "426": {
+            "MobID": 1923,
+            "MobDropID": 1030
+        },
+        "427": {
+            "MobID": 1986,
+            "MobDropID": 1121
+        },
+        "428": {
+            "MobID": 1988,
+            "MobDropID": 1161
+        },
+        "429": {
+            "MobID": 1989,
+            "MobDropID": 1320
+        },
+        "430": {
+            "MobID": 1990,
+            "MobDropID": 1001
+        },
+        "431": {
+            "MobID": 1992,
+            "MobDropID": 1281
+        },
+        "432": {
+            "MobID": 1998,
+            "MobDropID": 1041
+        },
+        "433": {
+            "MobID": 2029,
+            "MobDropID": 1241
+        },
+        "434": {
+            "MobID": 2030,
+            "MobDropID": 1400
+        },
+        "435": {
+            "MobID": 2031,
+            "MobDropID": 1311
+        },
+        "436": {
+            "MobID": 2032,
+            "MobDropID": 1310
+        },
+        "437": {
+            "MobID": 2033,
+            "MobDropID": 1312
+        },
+        "438": {
+            "MobID": 2034,
+            "MobDropID": 1311
+        },
+        "439": {
+            "MobID": 2036,
+            "MobDropID": 1271
+        },
+        "440": {
+            "MobID": 2037,
+            "MobDropID": 1272
+        },
+        "441": {
+            "MobID": 2039,
+            "MobDropID": 1090
+        },
+        "442": {
+            "MobID": 2044,
+            "MobDropID": 1091
+        },
+        "443": {
+            "MobID": 2046,
+            "MobDropID": 1092
+        },
+        "444": {
+            "MobID": 2048,
+            "MobDropID": 1130
+        },
+        "445": {
+            "MobID": 2049,
+            "MobDropID": 1131
+        },
+        "446": {
+            "MobID": 2051,
+            "MobDropID": 1171
+        },
+        "447": {
+            "MobID": 2052,
+            "MobDropID": 1171
+        },
+        "448": {
+            "MobID": 2053,
+            "MobDropID": 1212
+        },
+        "449": {
+            "MobID": 2054,
+            "MobDropID": 1211
+        },
+        "450": {
+            "MobID": 2058,
+            "MobDropID": 1250
+        },
+        "451": {
+            "MobID": 2059,
+            "MobDropID": 1290
+        },
+        "452": {
+            "MobID": 2060,
+            "MobDropID": 1330
+        },
+        "453": {
+            "MobID": 2063,
+            "MobDropID": 1331
+        },
+        "454": {
+            "MobID": 2066,
+            "MobDropID": 1370
+        },
+        "455": {
+            "MobID": 2067,
+            "MobDropID": 1371
+        },
+        "456": {
+            "MobID": 2071,
+            "MobDropID": 1411
+        },
+        "457": {
+            "MobID": 2073,
+            "MobDropID": 1081
+        },
+        "458": {
+            "MobID": 2041,
+            "MobDropID": 1090
+        },
+        "459": {
+            "MobID": 2075,
+            "MobDropID": 1082
+        },
+        "460": {
+            "MobID": 2078,
+            "MobDropID": 1080
+        },
+        "461": {
+            "MobID": 2080,
+            "MobDropID": 1162
+        },
+        "462": {
+            "MobID": 2082,
+            "MobDropID": 1200
+        },
+        "463": {
+            "MobID": 2084,
+            "MobDropID": 1200
+        },
+        "464": {
+            "MobID": 2085,
+            "MobDropID": 1242
+        },
+        "465": {
+            "MobID": 2086,
+            "MobDropID": 1240
+        },
+        "466": {
+            "MobID": 2087,
+            "MobDropID": 1282
+        },
+        "467": {
+            "MobID": 2088,
+            "MobDropID": 1321
+        },
+        "468": {
+            "MobID": 2089,
+            "MobDropID": 1322
+        },
+        "469": {
+            "MobID": 2093,
+            "MobDropID": 1361
+        },
+        "470": {
+            "MobID": 2095,
+            "MobDropID": 1402
+        },
+        "471": {
+            "MobID": 2097,
+            "MobDropID": 1100
+        },
+        "472": {
+            "MobID": 2098,
+            "MobDropID": 1101
+        },
+        "473": {
+            "MobID": 2099,
+            "MobDropID": 1100
+        },
+        "474": {
+            "MobID": 2100,
+            "MobDropID": 1102
+        },
+        "475": {
+            "MobID": 2102,
+            "MobDropID": 1101
+        },
+        "476": {
+            "MobID": 2103,
+            "MobDropID": 1100
+        },
+        "477": {
+            "MobID": 2104,
+            "MobDropID": 1102
+        },
+        "478": {
+            "MobID": 2105,
+            "MobDropID": 1141
+        },
+        "479": {
+            "MobID": 2106,
+            "MobDropID": 1140
+        },
+        "480": {
+            "MobID": 2107,
+            "MobDropID": 1142
+        },
+        "481": {
+            "MobID": 2108,
+            "MobDropID": 1180
+        },
+        "482": {
+            "MobID": 2109,
+            "MobDropID": 1181
+        },
+        "483": {
+            "MobID": 2110,
+            "MobDropID": 1181
+        },
+        "484": {
+            "MobID": 2111,
+            "MobDropID": 1222
+        },
+        "485": {
+            "MobID": 2112,
+            "MobDropID": 1220
+        },
+        "486": {
+            "MobID": 2113,
+            "MobDropID": 1221
+        },
         "487": {
-            "MobID": 2115,
-            "MobDropID": 424
+            "MobID": 2114,
+            "MobDropID": 1261
         },
         "488": {
-            "MobID": 2116,
-            "MobDropID": 127
+            "MobID": 2115,
+            "MobDropID": 1262
         },
         "489": {
-            "MobID": 2117,
-            "MobDropID": 284
+            "MobID": 2116,
+            "MobDropID": 1260
         },
         "490": {
-            "MobID": 2118,
-            "MobDropID": 135
+            "MobID": 2117,
+            "MobDropID": 1301
         },
         "491": {
-            "MobID": 2119,
-            "MobDropID": 428
+            "MobID": 2118,
+            "MobDropID": 1340
         },
         "492": {
-            "MobID": 2120,
-            "MobDropID": 288
+            "MobID": 2119,
+            "MobDropID": 1302
         },
         "493": {
-            "MobID": 2121,
-            "MobDropID": 432
+            "MobID": 2120,
+            "MobDropID": 1341
         },
         "494": {
-            "MobID": 2124,
-            "MobDropID": 292
+            "MobID": 2121,
+            "MobDropID": 1342
         },
         "495": {
-            "MobID": 2125,
-            "MobDropID": 436
+            "MobID": 2124,
+            "MobDropID": 1381
         },
         "496": {
-            "MobID": 2129,
-            "MobDropID": 440
+            "MobID": 2125,
+            "MobDropID": 1382
         },
         "497": {
-            "MobID": 2218,
-            "MobDropID": 88
+            "MobID": 2129,
+            "MobDropID": 1422
         },
         "498": {
-            "MobID": 2219,
-            "MobDropID": 95
+            "MobID": 2218,
+            "MobDropID": 870
         },
         "499": {
-            "MobID": 2220,
-            "MobDropID": 95
+            "MobID": 2219,
+            "MobDropID": 940
         },
         "500": {
-            "MobID": 2221,
-            "MobDropID": 95
+            "MobID": 2220,
+            "MobDropID": 940
         },
         "501": {
-            "MobID": 2223,
-            "MobDropID": 247
+            "MobID": 2221,
+            "MobDropID": 940
         },
         "502": {
-            "MobID": 2225,
-            "MobDropID": 397
+            "MobID": 2223,
+            "MobDropID": 921
         },
         "503": {
-            "MobID": 2226,
-            "MobDropID": 104
+            "MobID": 2225,
+            "MobDropID": 992
         },
         "504": {
-            "MobID": 2228,
-            "MobDropID": 98
+            "MobID": 2226,
+            "MobDropID": 1020
         },
         "505": {
-            "MobID": 2279,
-            "MobDropID": 120
+            "MobID": 2228,
+            "MobDropID": 960
         },
         "506": {
-            "MobID": 2309,
-            "MobDropID": 50
+            "MobID": 2279,
+            "MobDropID": 1190
         },
         "507": {
-            "MobID": 2320,
-            "MobDropID": 130
+            "MobID": 2309,
+            "MobDropID": 480
         },
         "508": {
-            "MobID": 2321,
-            "MobDropID": 131
+            "MobID": 2320,
+            "MobDropID": 1280
         },
         "509": {
-            "MobID": 2323,
-            "MobDropID": 138
+            "MobID": 2321,
+            "MobDropID": 1300
         },
         "510": {
-            "MobID": 2324,
-            "MobDropID": 139
+            "MobID": 2323,
+            "MobDropID": 1360
         },
         "511": {
-            "MobID": 2455,
-            "MobDropID": 295
+            "MobID": 2324,
+            "MobDropID": 1380
         },
         "512": {
-            "MobID": 2456,
-            "MobDropID": 296
+            "MobID": 2455,
+            "MobDropID": 1401
         },
         "513": {
-            "MobID": 2458,
-            "MobDropID": 142
+            "MobID": 2456,
+            "MobDropID": 1421
         },
         "514": {
-            "MobID": 2459,
-            "MobDropID": 143
+            "MobID": 2458,
+            "MobDropID": 1400
         },
         "515": {
-            "MobID": 2460,
-            "MobDropID": 294
+            "MobID": 2459,
+            "MobDropID": 1420
         },
         "516": {
-            "MobID": 2463,
-            "MobDropID": 295
+            "MobID": 2460,
+            "MobDropID": 1410
         },
         "517": {
-            "MobID": 2466,
-            "MobDropID": 143
+            "MobID": 2463,
+            "MobDropID": 1410
         },
         "518": {
-            "MobID": 2513,
-            "MobDropID": 2
+            "MobID": 2466,
+            "MobDropID": 1420
         },
         "519": {
-            "MobID": 2515,
-            "MobDropID": 6
+            "MobID": 2513,
+            "MobDropID": 0
         },
         "520": {
-            "MobID": 2589,
-            "MobDropID": 345
+            "MobID": 2515,
+            "MobDropID": 40
         },
         "521": {
-            "MobID": 2616,
-            "MobDropID": 80
+            "MobID": 2589,
+            "MobDropID": 472
         },
         "522": {
-            "MobID": 2625,
-            "MobDropID": 245
+            "MobID": 2616,
+            "MobDropID": 790
         },
         "523": {
-            "MobID": 2626,
-            "MobDropID": 391
+            "MobID": 2625,
+            "MobDropID": 911
         },
         "524": {
-            "MobID": 2837,
-            "MobDropID": 389
+            "MobID": 2626,
+            "MobDropID": 922
         },
         "525": {
-            "MobID": 2907,
-            "MobDropID": 440
+            "MobID": 2837,
+            "MobDropID": 912
         },
         "526": {
-            "MobID": 2908,
-            "MobDropID": 296
+            "MobID": 2907,
+            "MobDropID": 1432
         },
         "527": {
-            "MobID": 2909,
-            "MobDropID": 143
+            "MobID": 2908,
+            "MobDropID": 1431
         },
         "528": {
-            "MobID": 2912,
-            "MobDropID": 257
+            "MobID": 2909,
+            "MobDropID": 1430
         },
         "529": {
-            "MobID": 2913,
-            "MobDropID": 104
+            "MobID": 2912,
+            "MobDropID": 1031
         },
         "530": {
-            "MobID": 2914,
-            "MobDropID": 293
+            "MobID": 2913,
+            "MobDropID": 1020
         },
         "531": {
-            "MobID": 3038,
-            "MobDropID": 296
+            "MobID": 2914,
+            "MobDropID": 1391
         },
         "532": {
-            "MobID": 3122,
-            "MobDropID": 117
+            "MobID": 3038,
+            "MobDropID": 1421
         },
         "533": {
-            "MobID": 3145,
-            "MobDropID": 132
+            "MobID": 3122,
+            "MobDropID": 1210
         },
         "534": {
-            "MobID": 3285,
-            "MobDropID": 702
+            "MobID": 3145,
+            "MobDropID": 1310
         },
         "535": {
-            "MobID": 3286,
-            "MobDropID": 703
+            "MobID": 3285,
+            "MobDropID": 1442
         },
         "536": {
-            "MobID": 3287,
-            "MobDropID": 704
+            "MobID": 3286,
+            "MobDropID": 1443
         },
         "537": {
-            "MobID": 3288,
-            "MobDropID": 705
+            "MobID": 3287,
+            "MobDropID": 1444
         },
         "538": {
-            "MobID": 169,
-            "MobDropID": 65
+            "MobID": 3288,
+            "MobDropID": 1445
         },
         "539": {
-            "MobID": 415,
-            "MobDropID": 395
+            "MobID": 169,
+            "MobDropID": 650
         },
         "540": {
-            "MobID": 2464,
-            "MobDropID": 295
+            "MobID": 415,
+            "MobDropID": 962
         },
         "541": {
-            "MobID": 173,
-            "MobDropID": 70
+            "MobID": 2464,
+            "MobDropID": 1401
         },
         "542": {
-            "MobID": 2076,
-            "MobDropID": 109
+            "MobID": 173,
+            "MobDropID": 690
         },
         "543": {
-            "MobID": 26,
-            "MobDropID": 229
+            "MobID": 2076,
+            "MobDropID": 1080
         },
         "544": {
-            "MobID": 467,
-            "MobDropID": 11
+            "MobID": 26,
+            "MobDropID": 751
         },
         "545": {
-            "MobID": 468,
-            "MobDropID": 15
+            "MobID": 467,
+            "MobDropID": 100
         },
         "546": {
-            "MobID": 469,
-            "MobDropID": 15
+            "MobID": 468,
+            "MobDropID": 140
         },
         "547": {
-            "MobID": 470,
-            "MobDropID": 15
+            "MobID": 469,
+            "MobDropID": 140
         },
         "548": {
-            "MobID": 471,
-            "MobDropID": 7
+            "MobID": 470,
+            "MobDropID": 140
         },
         "549": {
-            "MobID": 472,
-            "MobDropID": 19
+            "MobID": 471,
+            "MobDropID": 21
         },
         "550": {
-            "MobID": 473,
-            "MobDropID": 19
-        },
-        "551": {
-            "MobID": 474,
-            "MobDropID": 19
-        },
-        "552": {
-            "MobID": 476,
-            "MobDropID": 23
-        },
-        "553": {
-            "MobID": 485,
-            "MobDropID": 27
-        },
-        "554": {
-            "MobID": 486,
+            "MobID": 472,
             "MobDropID": 180
         },
-        "555": {
-            "MobID": 501,
-            "MobDropID": 11
+        "551": {
+            "MobID": 473,
+            "MobDropID": 180
         },
-        "556": {
-            "MobID": 502,
-            "MobDropID": 188
+        "552": {
+            "MobID": 474,
+            "MobDropID": 180
         },
-        "557": {
-            "MobID": 505,
-            "MobDropID": 39
-        },
-        "558": {
-            "MobID": 506,
-            "MobDropID": 39
-        },
-        "559": {
-            "MobID": 507,
-            "MobDropID": 39
-        },
-        "560": {
-            "MobID": 508,
-            "MobDropID": 192
-        },
-        "561": {
-            "MobID": 516,
-            "MobDropID": 43
-        },
-        "562": {
-            "MobID": 517,
-            "MobDropID": 43
-        },
-        "563": {
-            "MobID": 518,
-            "MobDropID": 196
-        },
-        "564": {
-            "MobID": 522,
-            "MobDropID": 344
-        },
-        "565": {
-            "MobID": 523,
-            "MobDropID": 200
-        },
-        "566": {
-            "MobID": 527,
-            "MobDropID": 204
-        },
-        "567": {
-            "MobID": 528,
-            "MobDropID": 51
-        },
-        "568": {
-            "MobID": 529,
-            "MobDropID": 204
-        },
-        "569": {
-            "MobID": 556,
-            "MobDropID": 67
-        },
-        "570": {
-            "MobID": 557,
-            "MobDropID": 67
-        },
-        "571": {
-            "MobID": 558,
+        "553": {
+            "MobID": 476,
             "MobDropID": 220
         },
-        "572": {
-            "MobID": 560,
-            "MobDropID": 71
+        "554": {
+            "MobID": 485,
+            "MobDropID": 260
         },
-        "573": {
-            "MobID": 561,
-            "MobDropID": 71
+        "555": {
+            "MobID": 486,
+            "MobDropID": 261
         },
-        "574": {
-            "MobID": 578,
+        "556": {
+            "MobID": 501,
+            "MobDropID": 100
+        },
+        "557": {
+            "MobID": 502,
+            "MobDropID": 341
+        },
+        "558": {
+            "MobID": 505,
             "MobDropID": 380
         },
+        "559": {
+            "MobID": 506,
+            "MobDropID": 380
+        },
+        "560": {
+            "MobID": 507,
+            "MobDropID": 380
+        },
+        "561": {
+            "MobID": 508,
+            "MobDropID": 381
+        },
+        "562": {
+            "MobID": 516,
+            "MobDropID": 420
+        },
+        "563": {
+            "MobID": 517,
+            "MobDropID": 420
+        },
+        "564": {
+            "MobID": 518,
+            "MobDropID": 421
+        },
+        "565": {
+            "MobID": 522,
+            "MobDropID": 462
+        },
+        "566": {
+            "MobID": 523,
+            "MobDropID": 461
+        },
+        "567": {
+            "MobID": 527,
+            "MobDropID": 501
+        },
+        "568": {
+            "MobID": 528,
+            "MobDropID": 500
+        },
+        "569": {
+            "MobID": 529,
+            "MobDropID": 501
+        },
+        "570": {
+            "MobID": 556,
+            "MobDropID": 660
+        },
+        "571": {
+            "MobID": 557,
+            "MobDropID": 660
+        },
+        "572": {
+            "MobID": 558,
+            "MobDropID": 661
+        },
+        "573": {
+            "MobID": 560,
+            "MobDropID": 700
+        },
+        "574": {
+            "MobID": 561,
+            "MobDropID": 700
+        },
         "575": {
-            "MobID": 580,
-            "MobDropID": 236
+            "MobID": 578,
+            "MobDropID": 822
         },
         "576": {
-            "MobID": 587,
-            "MobDropID": 384
+            "MobID": 580,
+            "MobDropID": 821
         },
         "577": {
-            "MobID": 588,
-            "MobDropID": 384
+            "MobID": 587,
+            "MobDropID": 862
         },
         "578": {
-            "MobID": 1723,
-            "MobDropID": 348
+            "MobID": 588,
+            "MobDropID": 862
         },
         "579": {
-            "MobID": 1726,
-            "MobDropID": 348
+            "MobID": 1723,
+            "MobDropID": 502
         },
         "580": {
-            "MobID": 1729,
-            "MobDropID": 368
+            "MobID": 1726,
+            "MobDropID": 502
         },
         "581": {
-            "MobID": 2101,
-            "MobDropID": 111
+            "MobID": 1729,
+            "MobDropID": 702
         },
         "582": {
-            "MobID": 2467,
-            "MobDropID": 143
+            "MobID": 2101,
+            "MobDropID": 1100
         },
         "583": {
-            "MobID": 2468,
-            "MobDropID": 143
+            "MobID": 2467,
+            "MobDropID": 1420
         },
         "584": {
-            "MobID": 2469,
-            "MobDropID": 143
+            "MobID": 2468,
+            "MobDropID": 1420
         },
         "585": {
+            "MobID": 2469,
+            "MobDropID": 1420
+        },
+        "586": {
             "MobID": 2470,
-            "MobDropID": 143
+            "MobDropID": 1420
         }
     },
     "RarityWeights": {

--- a/patch/0104-fixes/drops.json
+++ b/patch/0104-fixes/drops.json
@@ -1,18 +1,49 @@
 {
     "MobDrops": {
-        "235": {
-            "!CrateDropTypeID": 86
+        "1163": {
+            "MobDropID": 1163,
+            "CrateDropChanceID": 0,
+            "CrateDropTypeID": 85,
+            "MiscDropChanceID": 0,
+            "MiscDropTypeID": 117
+        },
+        "1182": {
+            "MobDropID": 1182,
+            "CrateDropChanceID": 0,
+            "CrateDropTypeID": 85,
+            "MiscDropChanceID": 0,
+            "MiscDropTypeID": 119
+        },
+        "1201": {
+            "MobDropID": 1201,
+            "CrateDropChanceID": 0,
+            "CrateDropTypeID": 86,
+            "MiscDropChanceID": 0,
+            "MiscDropTypeID": 121
+        },
+        "1213": {
+            "MobDropID": 1213,
+            "CrateDropChanceID": 0,
+            "CrateDropTypeID": 86,
+            "MiscDropChanceID": 0,
+            "MiscDropTypeID": 122
         }
     },
     "Mobs": {
-        "427": {
-            "!MobDropID": 415
+        "428": {
+            "!MobDropID": 1163
         },
-        "480": {
-            "!MobDropID": 417
+        "448": {
+            "!MobDropID": 1213
         },
-        "532": {
-            "!MobDropID": 122
+        "462": {
+            "!MobDropID": 1201
+        },
+        "481": {
+            "!MobDropID": 1182
+        },
+        "533": {
+            "!MobDropID": 1211
         }
     }
 }

--- a/patch/1013-fixes/drops.json
+++ b/patch/1013-fixes/drops.json
@@ -1,44 +1,151 @@
 {
+    "MobDrops": {
+        "10302": {
+            "MobDropID": 302,
+            "CrateDropChanceID": 1,
+            "CrateDropTypeID": 92,
+            "MiscDropChanceID": 0,
+            "MiscDropTypeID": 31
+        },
+        "10382": {
+            "MobDropID": 382,
+            "CrateDropChanceID": 1,
+            "CrateDropTypeID": 93,
+            "MiscDropChanceID": 0,
+            "MiscDropTypeID": 39
+        },
+        "10473": {
+            "MobDropID": 473,
+            "CrateDropChanceID": 1,
+            "CrateDropTypeID": 106,
+            "MiscDropChanceID": 0,
+            "MiscDropTypeID": 48
+        },
+        "10592": {
+            "MobDropID": 592,
+            "CrateDropChanceID": 0,
+            "CrateDropTypeID": 70,
+            "MiscDropChanceID": 0,
+            "MiscDropTypeID": 60
+        },
+        "10611": {
+            "MobDropID": 611,
+            "CrateDropChanceID": 0,
+            "CrateDropTypeID": 105,
+            "MiscDropChanceID": 0,
+            "MiscDropTypeID": 62
+        },
+        "10623": {
+            "MobDropID": 623,
+            "CrateDropChanceID": 0,
+            "CrateDropTypeID": 105,
+            "MiscDropChanceID": 0,
+            "MiscDropTypeID": 63
+        },
+        "10703": {
+            "MobDropID": 703,
+            "CrateDropChanceID": 0,
+            "CrateDropTypeID": 104,
+            "MiscDropChanceID": 0,
+            "MiscDropTypeID": 71
+        },
+        "10711": {
+            "MobDropID": 711,
+            "CrateDropChanceID": 0,
+            "CrateDropTypeID": 73,
+            "MiscDropChanceID": 0,
+            "MiscDropTypeID": 72
+        },
+        "10712": {
+            "MobDropID": 712,
+            "CrateDropChanceID": 0,
+            "CrateDropTypeID": 104,
+            "MiscDropChanceID": 0,
+            "MiscDropTypeID": 72
+        }
+    },
     "Mobs": {
+        "10008": {
+            "!MobDropID": 580
+        },
+        "10009": {
+            "!MobDropID": 460
+        },
+        "10010": {
+            "!MobDropID": 620
+        },
+        "10011": {
+            "!MobDropID": 780
+        },
+        "10013": {
+            "!MobDropID": 703
+        },
+        "10014": {
+            "!MobDropID": 611
+        },
+        "10015": {
+            "!MobDropID": 611
+        },
+        "10016": {
+            "!MobDropID": 623
+        },
+        "10017": {
+            "!MobDropID": 611
+        },
+        "10028": {
+            "!MobDropID": 562
+        },
+        "10032": {
+            "!MobDropID": 473
+        },
+        "10033": {
+            "!MobDropID": 712
+        },
         "10035": {
-            "MobID": 3639,
-            "MobDropID": 191
+            "!MobDropID": 310
         },
         "10036": {
-            "MobID": 3640,
-            "MobDropID": 40
-        },
-        "10037": {
-            "MobID": 3641,
-            "MobDropID": 40
+            "!MobDropID": 790
         },
         "10038": {
-            "MobID": 3643,
-            "MobDropID": 369
+            "MobID": 3639,
+            "MobDropID": 361
         },
         "10039": {
-            "MobID": 3652,
-            "MobDropID": 191
+            "MobID": 3640,
+            "MobDropID": 380
         },
         "10040": {
-            "MobID": 3676,
-            "MobDropID": 44
+            "MobID": 3641,
+            "MobDropID": 390
         },
         "10041": {
-            "MobID": 3677,
-            "MobDropID": 357
+            "MobID": 3643,
+            "MobDropID": 711
         },
         "10042": {
-            "MobID": 3679,
-            "MobDropID": 707
+            "MobID": 3652,
+            "MobDropID": 381
         },
         "10043": {
-            "MobID": 3747,
-            "MobDropID": 20
+            "MobID": 3676,
+            "MobDropID": 430
         },
         "10044": {
+            "MobID": 3677,
+            "MobDropID": 592
+        },
+        "10045": {
+            "MobID": 3679,
+            "MobDropID": 712
+        },
+        "10046": {
+            "MobID": 3747,
+            "MobDropID": 190
+        },
+        "10047": {
             "MobID": 3748,
-            "MobDropID": 76
+            "MobDropID": 750
         }
     }
 }

--- a/patch/1013/drops.json
+++ b/patch/1013/drops.json
@@ -116,397 +116,304 @@
     },
     "MiscDropTypes": {
         "10000": {
-            "MiscDropTypeID": 123,
+            "MiscDropTypeID": 149,
             "PotionAmount": 0,
             "BoostAmount": 0,
             "TaroAmount": 5,
             "FMAmount": 0
         },
         "10001": {
-            "MiscDropTypeID": 124,
+            "MiscDropTypeID": 150,
             "PotionAmount": 0,
             "BoostAmount": 0,
             "TaroAmount": 100,
             "FMAmount": 0
-        },
-        "10002": {
-            "MiscDropTypeID": 125,
-            "PotionAmount": 17,
-            "BoostAmount": 17,
-            "TaroAmount": 37,
-            "FMAmount": 0
-        },
-        "10003": {
-            "MiscDropTypeID": 126,
-            "PotionAmount": 22,
-            "BoostAmount": 22,
-            "TaroAmount": 48,
-            "FMAmount": 0
-        },
-        "10004": {
-            "MiscDropTypeID": 127,
-            "PotionAmount": 23,
-            "BoostAmount": 23,
-            "TaroAmount": 120,
-            "FMAmount": 0
-        },
-        "10005": {
-            "MiscDropTypeID": 128,
-            "PotionAmount": 10,
-            "BoostAmount": 10,
-            "TaroAmount": 48,
-            "FMAmount": 16
-        },
-        "10006": {
-            "MiscDropTypeID": 129,
-            "PotionAmount": 0,
-            "BoostAmount": 0,
-            "TaroAmount": 46,
-            "FMAmount": 0
-        },
-        "10007": {
-            "MiscDropTypeID": 130,
-            "PotionAmount": 0,
-            "BoostAmount": 0,
-            "TaroAmount": 27,
-            "FMAmount": 45
-        },
-        "10008": {
-            "MiscDropTypeID": 131,
-            "PotionAmount": 0,
-            "BoostAmount": 0,
-            "TaroAmount": 7,
-            "FMAmount": 0
         }
     },
     "MobDrops": {
-        "353": {
-            "!CrateDropChanceID": 0,
-            "!CrateDropTypeID": 104,
-            "!MiscDropChanceID": 0,
-            "!MiscDropTypeID": 126
+        "10150": {
+            "MobDropID": 150,
+            "CrateDropChanceID": 0,
+            "CrateDropTypeID": 3,
+            "MiscDropChanceID": 0,
+            "MiscDropTypeID": 16
         },
-        "354": {
-            "!CrateDropChanceID": 0,
-            "!CrateDropTypeID": 104,
-            "!MiscDropChanceID": 0,
-            "!MiscDropTypeID": 127
-        },
-        "355": {
-            "!CrateDropChanceID": 0,
-            "!CrateDropTypeID": 105,
-            "!MiscDropChanceID": 0,
-            "!MiscDropTypeID": 128
-        },
-        "10000": {
-            "MobDropID": 725,
+        "10262": {
+            "MobDropID": 262,
             "CrateDropChanceID": 1,
             "CrateDropTypeID": 92,
             "MiscDropChanceID": 0,
-            "MiscDropTypeID": 117
+            "MiscDropTypeID": 27
         },
-        "10001": {
-            "MobDropID": 726,
-            "CrateDropChanceID": 1,
-            "CrateDropTypeID": 93,
-            "MiscDropChanceID": 0,
-            "MiscDropTypeID": 117
-        },
-        "10002": {
-            "MobDropID": 723,
-            "CrateDropChanceID": 1,
-            "CrateDropTypeID": 99,
-            "MiscDropChanceID": 0,
-            "MiscDropTypeID": 117
-        },
-        "10003": {
-            "MobDropID": 724,
-            "CrateDropChanceID": 2,
-            "CrateDropTypeID": 100,
-            "MiscDropChanceID": 0,
-            "MiscDropTypeID": 123
-        },
-        "10004": {
-            "MobDropID": 727,
-            "CrateDropChanceID": 1,
-            "CrateDropTypeID": 101,
-            "MiscDropChanceID": 0,
-            "MiscDropTypeID": 124
-        },
-        "10005": {
-            "MobDropID": 728,
-            "CrateDropChanceID": 1,
-            "CrateDropTypeID": 102,
-            "MiscDropChanceID": 0,
-            "MiscDropTypeID": 124
-        },
-        "10006": {
-            "MobDropID": 710,
+        "10282": {
+            "MobDropID": 282,
             "CrateDropChanceID": 0,
             "CrateDropTypeID": 103,
             "MiscDropChanceID": 0,
-            "MiscDropTypeID": 125
+            "MiscDropTypeID": 29
         },
-        "10007": {
-            "MobDropID": 732,
+        "10342": {
+            "MobDropID": 342,
+            "CrateDropChanceID": 1,
+            "CrateDropTypeID": 93,
+            "MiscDropChanceID": 0,
+            "MiscDropTypeID": 35
+        },
+        "10602": {
+            "MobDropID": 602,
+            "CrateDropChanceID": 0,
+            "CrateDropTypeID": 70,
+            "MiscDropChanceID": 0,
+            "MiscDropTypeID": 61
+        },
+        "10643": {
+            "MobDropID": 643,
+            "CrateDropChanceID": 0,
+            "CrateDropTypeID": 104,
+            "MiscDropChanceID": 0,
+            "MiscDropTypeID": 65
+        },
+        "10644": {
+            "MobDropID": 644,
+            "CrateDropChanceID": 0,
+            "CrateDropTypeID": 105,
+            "MiscDropChanceID": 0,
+            "MiscDropTypeID": 65
+        },
+        "10645": {
+            "MobDropID": 645,
             "CrateDropChanceID": 1,
             "CrateDropTypeID": 106,
             "MiscDropChanceID": 0,
-            "MiscDropTypeID": 129
+            "MiscDropTypeID": 65
         },
-        "10008": {
-            "MobDropID": 721,
-            "CrateDropChanceID": 1,
-            "CrateDropTypeID": 107,
+        "10663": {
+            "MobDropID": 663,
+            "CrateDropChanceID": 0,
+            "CrateDropTypeID": 104,
             "MiscDropChanceID": 0,
-            "MiscDropTypeID": 130
+            "MiscDropTypeID": 67
         },
-        "10009": {
-            "MobDropID": 722,
-            "CrateDropChanceID": 1,
-            "CrateDropTypeID": 108,
+        "10664": {
+            "MobDropID": 664,
+            "CrateDropChanceID": 0,
+            "CrateDropTypeID": 105,
             "MiscDropChanceID": 0,
-            "MiscDropTypeID": 131
+            "MiscDropTypeID": 67
         },
-        "10010": {
-            "MobDropID": 733,
+        "11449": {
+            "MobDropID": 1449,
+            "CrateDropChanceID": 1,
+            "CrateDropTypeID": 99,
+            "MiscDropChanceID": 0,
+            "MiscDropTypeID": 0
+        },
+        "11450": {
+            "MobDropID": 1450,
+            "CrateDropChanceID": 1,
+            "CrateDropTypeID": 101,
+            "MiscDropChanceID": 0,
+            "MiscDropTypeID": 150
+        },
+        "11451": {
+            "MobDropID": 1451,
+            "CrateDropChanceID": 1,
+            "CrateDropTypeID": 102,
+            "MiscDropChanceID": 0,
+            "MiscDropTypeID": 150
+        },
+        "11452": {
+            "MobDropID": 1452,
+            "CrateDropChanceID": 2,
+            "CrateDropTypeID": 100,
+            "MiscDropChanceID": 0,
+            "MiscDropTypeID": 149
+        },
+        "11453": {
+            "MobDropID": 1453,
             "CrateDropChanceID": 3,
             "CrateDropTypeID": 109,
             "MiscDropChanceID": 1,
-            "MiscDropTypeID": 117
+            "MiscDropTypeID": 0
         },
-        "10011": {
-            "MobDropID": 734,
+        "11454": {
+            "MobDropID": 1454,
             "CrateDropChanceID": 3,
             "CrateDropTypeID": 110,
             "MiscDropChanceID": 1,
-            "MiscDropTypeID": 117
+            "MiscDropTypeID": 0
         },
-        "10012": {
-            "MobDropID": 735,
+        "11455": {
+            "MobDropID": 1455,
             "CrateDropChanceID": 3,
             "CrateDropTypeID": 111,
             "MiscDropChanceID": 1,
-            "MiscDropTypeID": 117
+            "MiscDropTypeID": 0
         }
     },
     "Events": {
         "0": {
-            "!MobDropID": 733
+            "!MobDropID": 1453
         },
         "1": {
-            "!MobDropID": 734
+            "!MobDropID": 1454
         },
         "2": {
-            "!MobDropID": 735
+            "!MobDropID": 1455
         }
     },
     "Mobs": {
-        "0": {
-            "!MobDropID": 40
-        },
-        "6": {
-            "!MobDropID": 15
-        },
-        "16": {
-            "!MobDropID": 24
-        },
-        "37": {
-            "!MobDropID": 76
-        },
-        "43": {
-            "!MobDropID": 724
-        },
-        "44": {
-            "!MobDropID": 17
-        },
-        "50": {
-            "!MobDropID": 186
-        },
-        "54": {
-            "!MobID": 79
-        },
-        "56": {
-            "!MobDropID": 724
-        },
-        "133": {
-            "!MobID": 253
-        },
-        "143": {
-            "!MobDropID": 14
-        },
-        "241": {
-            "!MobDropID": 723
-        },
-        "243": {
-            "!MobDropID": 19
-        },
-        "249": {
-            "!MobDropID": 725
-        },
-        "254": {
-            "!MobDropID": 726
-        },
-        "377": {
-            "!MobDropID": 187
-        },
-        "518": {
-            "!MobDropID": 14
-        },
-        "519": {
-            "!MobDropID": 18
-        },
         "10000": {
             "MobID": 18,
-            "MobDropID": 209
+            "MobDropID": 550
+        },
+        "10001": {
+            "MobID": 357,
+            "MobDropID": 560
         },
         "10002": {
-            "MobID": 357,
-            "MobDropID": 58
+            "MobID": 387,
+            "MobDropID": 720
         },
         "10003": {
-            "MobID": 387,
-            "MobDropID": 74
+            "MobID": 3144,
+            "MobDropID": 472
+        },
+        "10004": {
+            "MobID": 3370,
+            "MobDropID": 440
+        },
+        "10005": {
+            "MobID": 3371,
+            "MobDropID": 600
         },
         "10006": {
-            "MobID": 3144,
-            "MobDropID": 345
+            "MobID": 3372,
+            "MobDropID": 760
         },
         "10007": {
-            "MobID": 3370,
-            "MobDropID": 46
+            "MobID": 3373,
+            "MobDropID": 570
         },
         "10008": {
-            "MobID": 3371,
-            "MobDropID": 62
+            "MobID": 3374,
+            "MobDropID": 560
         },
         "10009": {
-            "MobID": 3372,
-            "MobDropID": 78
+            "MobID": 3375,
+            "MobDropID": 440
         },
         "10010": {
-            "MobID": 3373,
-            "MobDropID": 58
+            "MobID": 3376,
+            "MobDropID": 600
         },
         "10011": {
-            "MobID": 3374,
-            "MobDropID": 59
+            "MobID": 3377,
+            "MobDropID": 760
         },
         "10012": {
-            "MobID": 3375,
-            "MobDropID": 46
+            "MobID": 3402,
+            "MobDropID": 643
         },
         "10013": {
-            "MobID": 3376,
-            "MobDropID": 62
+            "MobID": 3403,
+            "MobDropID": 663
         },
         "10014": {
-            "MobID": 3377,
-            "MobDropID": 78
+            "MobID": 3432,
+            "MobDropID": 644
         },
         "10015": {
-            "MobID": 3402,
-            "MobDropID": 706
+            "MobID": 3433,
+            "MobDropID": 644
         },
         "10016": {
-            "MobID": 3403,
-            "MobDropID": 707
+            "MobID": 3434,
+            "MobDropID": 664
         },
         "10017": {
-            "MobID": 3432,
-            "MobDropID": 708
+            "MobID": 3435,
+            "MobDropID": 644
         },
         "10018": {
-            "MobID": 3433,
-            "MobDropID": 708
+            "MobID": 3498,
+            "MobDropID": 282
         },
         "10019": {
-            "MobID": 3434,
-            "MobDropID": 708
+            "MobID": 3540,
+            "MobDropID": 442
         },
         "10020": {
-            "MobID": 3435,
-            "MobDropID": 708
+            "MobID": 3541,
+            "MobDropID": 462
         },
         "10021": {
-            "MobID": 3498,
-            "MobDropID": 710
+            "MobID": 3543,
+            "MobDropID": 462
         },
         "10022": {
-            "MobID": 3540,
-            "MobDropID": 343
+            "MobID": 3589,
+            "MobDropID": 1452
         },
         "10023": {
-            "MobID": 3541,
-            "MobDropID": 344
+            "MobID": 3590,
+            "MobDropID": 1452
         },
         "10024": {
-            "MobID": 3543,
-            "MobDropID": 344
+            "MobID": 3596,
+            "MobDropID": 1452
         },
         "10025": {
-            "MobID": 3589,
-            "MobDropID": 724
+            "MobID": 3597,
+            "MobDropID": 1450
         },
         "10026": {
-            "MobID": 3590,
-            "MobDropID": 724
+            "MobID": 3598,
+            "MobDropID": 1451
         },
         "10027": {
-            "MobID": 3596,
-            "MobDropID": 724
+            "MobID": 3618,
+            "MobDropID": 280
         },
         "10028": {
-            "MobID": 3597,
-            "MobDropID": 727
+            "MobID": 3620,
+            "MobDropID": 602
         },
         "10029": {
-            "MobID": 3598,
-            "MobDropID": 728
+            "MobID": 3621,
+            "MobDropID": 120
         },
         "10030": {
-            "MobID": 3618,
-            "MobDropID": 30
+            "MobID": 3622,
+            "MobDropID": 1452
         },
         "10031": {
-            "MobID": 3620,
-            "MobDropID": 355
+            "MobID": 3629,
+            "MobDropID": 200
         },
         "10032": {
-            "MobID": 3621,
-            "MobDropID": 14
+            "MobID": 3749,
+            "MobDropID": 645
         },
         "10033": {
-            "MobID": 3622,
-            "MobDropID": 724
+            "MobID": 3760,
+            "MobDropID": 663
         },
         "10034": {
-            "MobID": 3629,
-            "MobDropID": 22
-        },
-        "10045": {
-            "MobID": 3749,
-            "MobDropID": 732
-        },
-        "10046": {
-            "MobID": 3760,
-            "MobDropID": 707
-        },
-        "10047": {
             "MobID": 3763,
-            "MobDropID": 26
+            "MobDropID": 240
         },
-        "10048": {
+        "10035": {
             "MobID": 3764,
-            "MobDropID": 30
+            "MobDropID": 280
         },
-        "10049": {
+        "10036": {
             "MobID": 3769,
-            "MobDropID": 78
+            "MobDropID": 760
         },
-        "10050": {
+        "10037": {
             "MobID": 3619,
-            "MobDropID": 188
+            "MobDropID": 341
         }
     },
     "RarityWeights": {

--- a/patch/1013/drops.json
+++ b/patch/1013/drops.json
@@ -5131,6 +5131,16 @@
             "ItemReferenceID": 2229,
             "ItemID": 67,
             "Type": 6
+        },
+        "10219": {
+            "ItemReferenceID": 2230,
+            "ItemID": 80,
+            "Type": 6
+        },
+        "10220": {
+            "ItemReferenceID": 2231,
+            "ItemID": 38,
+            "Type": 10
         }
     },
     "NanoCapsules": {
@@ -5745,7 +5755,9 @@
                 2166,
                 2167,
                 2168,
-                2169
+                2169,
+                2230,
+                2231
             ]
         },
         "93": {

--- a/patch/1013/drops.json
+++ b/patch/1013/drops.json
@@ -452,6 +452,657 @@
                 "162": 1
             }
         },
+        "109": {
+            "!DefaultItemWeight": 9,
+            "AlterRarityMap": {
+                "2224": 3,
+                "2222": 3,
+                "2223": 3
+            },
+            "AlterItemWeightMap": {
+                "2224": 1,
+                "2222": 1,
+                "2223": 1
+            },
+            "!ItemReferenceIDs": [
+                230,
+                248,
+                286,
+                2222,
+                2223,
+                2224
+            ]
+        },
+        "112": {
+            "!DefaultItemWeight": 9,
+            "AlterRarityMap": {
+                "2224": 3,
+                "2222": 3,
+                "2223": 3
+            },
+            "AlterItemWeightMap": {
+                "2224": 1,
+                "2222": 1,
+                "2223": 1
+            },
+            "!ItemReferenceIDs": [
+                322,
+                332,
+                357,
+                2222,
+                2223,
+                2224
+            ]
+        },
+        "115": {
+            "!DefaultItemWeight": 9,
+            "AlterRarityMap": {
+                "2224": 3,
+                "2222": 3,
+                "2223": 3
+            },
+            "AlterItemWeightMap": {
+                "2224": 1,
+                "2222": 1,
+                "2223": 1
+            },
+            "!ItemReferenceIDs": [
+                322,
+                332,
+                357,
+                2222,
+                2223,
+                2224
+            ]
+        },
+        "118": {
+            "!DefaultItemWeight": 9,
+            "AlterRarityMap": {
+                "2224": 3,
+                "2222": 3,
+                "2223": 3
+            },
+            "AlterItemWeightMap": {
+                "2224": 1,
+                "2222": 1,
+                "2223": 1
+            },
+            "!ItemReferenceIDs": [
+                322,
+                332,
+                357,
+                2222,
+                2223,
+                2224
+            ]
+        },
+        "121": {
+            "!DefaultItemWeight": 9,
+            "AlterRarityMap": {
+                "2224": 3,
+                "2222": 3,
+                "2223": 3
+            },
+            "AlterItemWeightMap": {
+                "2224": 1,
+                "2222": 1,
+                "2223": 1
+            },
+            "!ItemReferenceIDs": [
+                948,
+                958,
+                969,
+                2222,
+                2223,
+                2224
+            ]
+        },
+        "124": {
+            "!DefaultItemWeight": 9,
+            "AlterRarityMap": {
+                "2224": 3,
+                "2222": 3,
+                "2223": 3
+            },
+            "AlterItemWeightMap": {
+                "2224": 1,
+                "2222": 1,
+                "2223": 1
+            },
+            "!ItemReferenceIDs": [
+                948,
+                958,
+                969,
+                2222,
+                2223,
+                2224
+            ]
+        },
+        "127": {
+            "!DefaultItemWeight": 9,
+            "AlterRarityMap": {
+                "2224": 3,
+                "2222": 3,
+                "2223": 3
+            },
+            "AlterItemWeightMap": {
+                "2224": 1,
+                "2222": 1,
+                "2223": 1
+            },
+            "!ItemReferenceIDs": [
+                948,
+                958,
+                969,
+                2222,
+                2223,
+                2224
+            ]
+        },
+        "130": {
+            "!DefaultItemWeight": 9,
+            "AlterRarityMap": {
+                "2224": 3,
+                "2222": 3,
+                "2223": 3
+            },
+            "AlterItemWeightMap": {
+                "2224": 1,
+                "2222": 1,
+                "2223": 1
+            },
+            "!ItemReferenceIDs": [
+                977,
+                997,
+                1004,
+                2222,
+                2223,
+                2224
+            ]
+        },
+        "133": {
+            "!DefaultItemWeight": 9,
+            "AlterRarityMap": {
+                "2224": 3,
+                "2222": 3,
+                "2223": 3
+            },
+            "AlterItemWeightMap": {
+                "2224": 1,
+                "2222": 1,
+                "2223": 1
+            },
+            "!ItemReferenceIDs": [
+                977,
+                997,
+                1004,
+                2222,
+                2223,
+                2224
+            ]
+        },
+        "136": {
+            "!DefaultItemWeight": 9,
+            "AlterRarityMap": {
+                "2224": 3,
+                "2222": 3,
+                "2223": 3
+            },
+            "AlterItemWeightMap": {
+                "2224": 1,
+                "2222": 1,
+                "2223": 1
+            },
+            "!ItemReferenceIDs": [
+                977,
+                997,
+                1004,
+                2222,
+                2223,
+                2224
+            ]
+        },
+        "139": {
+            "!DefaultItemWeight": 9,
+            "AlterRarityMap": {
+                "2224": 3,
+                "2222": 3,
+                "2223": 3
+            },
+            "AlterItemWeightMap": {
+                "2224": 1,
+                "2222": 1,
+                "2223": 1
+            },
+            "!ItemReferenceIDs": [
+                470,
+                1015,
+                1025,
+                2222,
+                2223,
+                2224
+            ]
+        },
+        "142": {
+            "!DefaultItemWeight": 9,
+            "AlterRarityMap": {
+                "2224": 3,
+                "2222": 3,
+                "2223": 3
+            },
+            "AlterItemWeightMap": {
+                "2224": 1,
+                "2222": 1,
+                "2223": 1
+            },
+            "!ItemReferenceIDs": [
+                470,
+                1015,
+                1025,
+                2222,
+                2223,
+                2224
+            ]
+        },
+        "145": {
+            "!DefaultItemWeight": 9,
+            "AlterRarityMap": {
+                "2224": 3,
+                "2222": 3,
+                "2223": 3
+            },
+            "AlterItemWeightMap": {
+                "2224": 1,
+                "2222": 1,
+                "2223": 1
+            },
+            "!ItemReferenceIDs": [
+                470,
+                1015,
+                1025,
+                2222,
+                2223,
+                2224
+            ]
+        },
+        "148": {
+            "!DefaultItemWeight": 9,
+            "AlterRarityMap": {
+                "2224": 4,
+                "2222": 4,
+                "2223": 4
+            },
+            "AlterItemWeightMap": {
+                "2224": 1,
+                "2222": 1,
+                "2223": 1
+            },
+            "!ItemReferenceIDs": [
+                546,
+                1067,
+                1080,
+                2222,
+                2223,
+                2224
+            ]
+        },
+        "151": {
+            "!DefaultItemWeight": 9,
+            "AlterRarityMap": {
+                "2224": 4,
+                "2222": 4,
+                "2223": 4
+            },
+            "AlterItemWeightMap": {
+                "2224": 1,
+                "2222": 1,
+                "2223": 1
+            },
+            "!ItemReferenceIDs": [
+                546,
+                1067,
+                1080,
+                2222,
+                2223,
+                2224
+            ]
+        },
+        "154": {
+            "!DefaultItemWeight": 9,
+            "AlterRarityMap": {
+                "2224": 4,
+                "2222": 4,
+                "2223": 4
+            },
+            "AlterItemWeightMap": {
+                "2224": 1,
+                "2222": 1,
+                "2223": 1
+            },
+            "!ItemReferenceIDs": [
+                546,
+                1067,
+                1080,
+                2222,
+                2223,
+                2224
+            ]
+        },
+        "157": {
+            "!DefaultItemWeight": 9,
+            "AlterRarityMap": {
+                "2224": 4,
+                "2222": 4,
+                "2223": 4
+            },
+            "AlterItemWeightMap": {
+                "2224": 1,
+                "2222": 1,
+                "2223": 1
+            },
+            "!ItemReferenceIDs": [
+                1107,
+                1107,
+                1148,
+                2222,
+                2223,
+                2224
+            ]
+        },
+        "160": {
+            "!DefaultItemWeight": 9,
+            "AlterRarityMap": {
+                "2224": 4,
+                "2222": 4,
+                "2223": 4
+            },
+            "AlterItemWeightMap": {
+                "2224": 1,
+                "2222": 1,
+                "2223": 1
+            },
+            "!ItemReferenceIDs": [
+                1107,
+                1107,
+                1148,
+                2222,
+                2223,
+                2224
+            ]
+        },
+        "163": {
+            "!DefaultItemWeight": 9,
+            "AlterRarityMap": {
+                "2224": 4,
+                "2222": 4,
+                "2223": 4
+            },
+            "AlterItemWeightMap": {
+                "2224": 1,
+                "2222": 1,
+                "2223": 1
+            },
+            "!ItemReferenceIDs": [
+                1107,
+                1107,
+                1148,
+                2222,
+                2223,
+                2224
+            ]
+        },
+        "166": {
+            "!DefaultItemWeight": 9,
+            "AlterRarityMap": {
+                "2224": 4,
+                "2222": 4,
+                "2223": 4
+            },
+            "AlterItemWeightMap": {
+                "2224": 1,
+                "2222": 1,
+                "2223": 1
+            },
+            "!ItemReferenceIDs": [
+                656,
+                1606,
+                1627,
+                2222,
+                2223,
+                2224
+            ]
+        },
+        "169": {
+            "!DefaultItemWeight": 9,
+            "AlterRarityMap": {
+                "2224": 4,
+                "2222": 4,
+                "2223": 4
+            },
+            "AlterItemWeightMap": {
+                "2224": 1,
+                "2222": 1,
+                "2223": 1
+            },
+            "!ItemReferenceIDs": [
+                656,
+                1606,
+                1627,
+                2222,
+                2223,
+                2224
+            ]
+        },
+        "172": {
+            "!DefaultItemWeight": 9,
+            "AlterRarityMap": {
+                "2224": 4,
+                "2222": 4,
+                "2223": 4
+            },
+            "AlterItemWeightMap": {
+                "2224": 1,
+                "2222": 1,
+                "2223": 1
+            },
+            "!ItemReferenceIDs": [
+                656,
+                1606,
+                1627,
+                2222,
+                2223,
+                2224
+            ]
+        },
+        "175": {
+            "!DefaultItemWeight": 9,
+            "AlterRarityMap": {
+                "2224": 4,
+                "2222": 4,
+                "2223": 4
+            },
+            "AlterItemWeightMap": {
+                "2224": 1,
+                "2222": 1,
+                "2223": 1
+            },
+            "!ItemReferenceIDs": [
+                674,
+                692,
+                728,
+                2222,
+                2223,
+                2224
+            ]
+        },
+        "178": {
+            "!DefaultItemWeight": 9,
+            "AlterRarityMap": {
+                "2224": 4,
+                "2222": 4,
+                "2223": 4
+            },
+            "AlterItemWeightMap": {
+                "2224": 1,
+                "2222": 1,
+                "2223": 1
+            },
+            "!ItemReferenceIDs": [
+                674,
+                692,
+                728,
+                2222,
+                2223,
+                2224
+            ]
+        },
+        "181": {
+            "!DefaultItemWeight": 9,
+            "AlterRarityMap": {
+                "2224": 4,
+                "2222": 4,
+                "2223": 4
+            },
+            "AlterItemWeightMap": {
+                "2224": 1,
+                "2222": 1,
+                "2223": 1
+            },
+            "!ItemReferenceIDs": [
+                674,
+                692,
+                728,
+                2222,
+                2223,
+                2224
+            ]
+        },
+        "184": {
+            "!DefaultItemWeight": 9,
+            "AlterRarityMap": {
+                "2224": 4,
+                "2222": 4,
+                "2223": 4
+            },
+            "AlterItemWeightMap": {
+                "2224": 1,
+                "2222": 1,
+                "2223": 1
+            },
+            "!ItemReferenceIDs": [
+                767,
+                1737,
+                1779,
+                2222,
+                2223,
+                2224
+            ]
+        },
+        "187": {
+            "!DefaultItemWeight": 9,
+            "AlterRarityMap": {
+                "2224": 4,
+                "2222": 4,
+                "2223": 4
+            },
+            "AlterItemWeightMap": {
+                "2224": 1,
+                "2222": 1,
+                "2223": 1
+            },
+            "!ItemReferenceIDs": [
+                767,
+                1737,
+                1779,
+                2222,
+                2223,
+                2224
+            ]
+        },
+        "190": {
+            "!DefaultItemWeight": 9,
+            "AlterRarityMap": {
+                "2224": 4,
+                "2222": 4,
+                "2223": 4
+            },
+            "AlterItemWeightMap": {
+                "2224": 1,
+                "2222": 1,
+                "2223": 1
+            },
+            "!ItemReferenceIDs": [
+                767,
+                1737,
+                1779,
+                2222,
+                2223,
+                2224
+            ]
+        },
+        "193": {
+            "!DefaultItemWeight": 9,
+            "AlterRarityMap": {
+                "2224": 4,
+                "2222": 4,
+                "2223": 4
+            },
+            "AlterItemWeightMap": {
+                "2224": 1,
+                "2222": 1,
+                "2223": 1
+            },
+            "!ItemReferenceIDs": [
+                1367,
+                1397,
+                1802,
+                2222,
+                2223,
+                2224
+            ]
+        },
+        "196": {
+            "!DefaultItemWeight": 9,
+            "AlterRarityMap": {
+                "2224": 4,
+                "2222": 4,
+                "2223": 4
+            },
+            "AlterItemWeightMap": {
+                "2224": 1,
+                "2222": 1,
+                "2223": 1
+            },
+            "!ItemReferenceIDs": [
+                1367,
+                1397,
+                1802,
+                2222,
+                2223,
+                2224
+            ]
+        },
+        "199": {
+            "!DefaultItemWeight": 9,
+            "AlterRarityMap": {
+                "2224": 4,
+                "2222": 4,
+                "2223": 4
+            },
+            "AlterItemWeightMap": {
+                "2224": 1,
+                "2222": 1,
+                "2223": 1
+            },
+            "!ItemReferenceIDs": [
+                1367,
+                1397,
+                1802,
+                2222,
+                2223,
+                2224
+            ]
+        },
         "201": {
             "!ItemReferenceIDs": [
                 1864,
@@ -584,12 +1235,20 @@
             ]
         },
         "282": {
+            "!DefaultItemWeight": 3,
+            "AlterRarityMap": {
+                "2225": 3
+            },
+            "AlterItemWeightMap": {
+                "2225": 1
+            },
             "!ItemReferenceIDs": [
                 2042,
                 2043,
                 2044,
                 2045,
-                2046
+                2046,
+                2225
             ]
         },
         "283": {
@@ -2491,6 +3150,136 @@
                 1851,
                 1852
             ]
+        },
+        "10019": {
+            "ItemSetID": 336,
+            "IgnoreRarity": false,
+            "IgnoreGender": false,
+            "DefaultItemWeight": 1,
+            "AlterRarityMap": {
+                "2224": 4,
+                "2222": 4,
+                "2223": 4
+            },
+            "AlterGenderMap": {},
+            "AlterItemWeightMap": {
+                "1996": 7
+            },
+            "ItemReferenceIDs": [
+                1996,
+                2222,
+                2223,
+                2224
+            ]
+        },
+        "10020": {
+            "ItemSetID": 337,
+            "IgnoreRarity": false,
+            "IgnoreGender": false,
+            "DefaultItemWeight": 1,
+            "AlterRarityMap": {
+                "2224": 4,
+                "2228": 4,
+                "2222": 4,
+                "2223": 4
+            },
+            "AlterGenderMap": {},
+            "AlterItemWeightMap": {
+                "2228": 7
+            },
+            "ItemReferenceIDs": [
+                2222,
+                2223,
+                2224,
+                2228
+            ]
+        },
+        "10021": {
+            "ItemSetID": 338,
+            "IgnoreRarity": false,
+            "IgnoreGender": false,
+            "DefaultItemWeight": 1,
+            "AlterRarityMap": {
+                "2224": 4,
+                "353": 4,
+                "2222": 4,
+                "2223": 4
+            },
+            "AlterGenderMap": {},
+            "AlterItemWeightMap": {
+                "353": 7
+            },
+            "ItemReferenceIDs": [
+                353,
+                2222,
+                2223,
+                2224
+            ]
+        },
+        "10022": {
+            "ItemSetID": 339,
+            "IgnoreRarity": false,
+            "IgnoreGender": false,
+            "DefaultItemWeight": 1,
+            "AlterRarityMap": {
+                "2224": 4,
+                "2222": 4,
+                "2223": 4
+            },
+            "AlterGenderMap": {},
+            "AlterItemWeightMap": {
+                "2229": 7
+            },
+            "ItemReferenceIDs": [
+                2222,
+                2223,
+                2224,
+                2229
+            ]
+        },
+        "10023": {
+            "ItemSetID": 340,
+            "IgnoreRarity": false,
+            "IgnoreGender": false,
+            "DefaultItemWeight": 3,
+            "AlterRarityMap": {
+                "2224": 4,
+                "2225": 4,
+                "2222": 4,
+                "2223": 4
+            },
+            "AlterGenderMap": {},
+            "AlterItemWeightMap": {
+                "2225": 1
+            },
+            "ItemReferenceIDs": [
+                2222,
+                2223,
+                2224,
+                2225
+            ]
+        },
+        "10024": {
+            "ItemSetID": 341,
+            "IgnoreRarity": false,
+            "IgnoreGender": false,
+            "DefaultItemWeight": 1,
+            "AlterRarityMap": {
+                "2224": 4,
+                "2222": 4,
+                "2223": 4,
+                "2227": 4
+            },
+            "AlterGenderMap": {},
+            "AlterItemWeightMap": {
+                "2227": 7
+            },
+            "ItemReferenceIDs": [
+                2222,
+                2223,
+                2224,
+                2227
+            ]
         }
     },
     "Crates": {
@@ -2947,6 +3736,18 @@
         "835": {
             "!RarityWeightID": 1
         },
+        "836": {
+            "!ItemSetID": 339
+        },
+        "837": {
+            "!ItemSetID": 338
+        },
+        "838": {
+            "!ItemSetID": 337
+        },
+        "839": {
+            "!ItemSetID": 336
+        },
         "10000": {
             "CrateID": 1237,
             "ItemSetID": 200,
@@ -3111,6 +3912,16 @@
             "CrateID": 1260,
             "ItemSetID": 291,
             "RarityWeightID": 11
+        },
+        "10033": {
+            "CrateID": 1219,
+            "ItemSetID": 340,
+            "RarityWeightID": 6
+        },
+        "10034": {
+            "CrateID": 1192,
+            "ItemSetID": 341,
+            "RarityWeightID": 6
         }
     },
     "ItemReferences": {
@@ -4280,6 +5091,46 @@
             "ItemReferenceID": 2221,
             "ItemID": 407,
             "Type": 3
+        },
+        "10211": {
+            "ItemReferenceID": 2222,
+            "ItemID": 153,
+            "Type": 7
+        },
+        "10212": {
+            "ItemReferenceID": 2223,
+            "ItemID": 154,
+            "Type": 7
+        },
+        "10213": {
+            "ItemReferenceID": 2224,
+            "ItemID": 155,
+            "Type": 7
+        },
+        "10214": {
+            "ItemReferenceID": 2225,
+            "ItemID": 156,
+            "Type": 7
+        },
+        "10215": {
+            "ItemReferenceID": 2226,
+            "ItemID": 1219,
+            "Type": 9
+        },
+        "10216": {
+            "ItemReferenceID": 2227,
+            "ItemID": 168,
+            "Type": 4
+        },
+        "10217": {
+            "ItemReferenceID": 2228,
+            "ItemID": 150,
+            "Type": 4
+        },
+        "10218": {
+            "ItemReferenceID": 2229,
+            "ItemID": 67,
+            "Type": 6
         }
     },
     "NanoCapsules": {
@@ -4844,7 +5695,8 @@
         "86": {
             "Code": "ffcnoblewarriors",
             "ItemReferenceIDs": [
-                2150
+                2150,
+                2226
             ]
         },
         "87": {

--- a/patch/1013/drops.json
+++ b/patch/1013/drops.json
@@ -5141,6 +5141,11 @@
             "ItemReferenceID": 2231,
             "ItemID": 38,
             "Type": 10
+        },
+        "10221": {
+            "ItemReferenceID": 2232,
+            "ItemID": 1187,
+            "Type": 9
         }
     },
     "NanoCapsules": {
@@ -5665,19 +5670,22 @@
         "80": {
             "Code": "ffcthekingofcool",
             "ItemReferenceIDs": [
-                2140
+                2140,
+                2232
             ]
         },
         "81": {
             "Code": "ffcstealthyninja",
             "ItemReferenceIDs": [
-                2141
+                2141,
+                2232
             ]
         },
         "82": {
             "Code": "ffcrevtheengines",
             "ItemReferenceIDs": [
-                2142
+                2142,
+                2232
             ]
         },
         "83": {
@@ -5699,7 +5707,8 @@
         "85": {
             "Code": "ffchighflyingfun",
             "ItemReferenceIDs": [
-                2149
+                2149,
+                2232
             ]
         },
         "86": {
@@ -5712,13 +5721,15 @@
         "87": {
             "Code": "ffchalfkaijuking",
             "ItemReferenceIDs": [
-                2151
+                2151,
+                2232
             ]
         },
         "88": {
             "Code": "ffcultimatemagik",
             "ItemReferenceIDs": [
-                2152
+                2152,
+                2232
             ]
         },
         "89": {


### PR DESCRIPTION
## Warning
Merge #24 before merging this PR.

## Features
- Fixes all monster reward FM / Taro / Boost / Potion values to their (hopefully) authentic values, and provides fixed versions where applicable.
- `MiscDropType 0` now signifies no drops. `MiscDropType`s following that follow this format up until and including level 36:
  - `MiscDropType (i - 1) * 4 + 1` is the reward for single mobs of level `i`.
  - `MiscDropType (i - 1) * 4 + 2` is the reward for group mobs of level `i`.
  - `MiscDropType (i - 1) * 4 + 3` is the reward for boss mobs of level `i`.
  - `MiscDropType (i - 1) * 4 + 4` is the reward for fusion mobs of level `i`.
- The following `MiscDropType`s after that are free-form, and contain things like Blowfish rewards, and for Academy, the Academy tutorial reward values.
- `MobDrop`s now follow the following pattern until and up to level 36, leaving IDs unused if there aren't a need for separate `MobDrop`s:
  - `MobDrop (i - 1) * 40` to `(i - 1) * 40 + 9` is the mob drops for single mobs of level `i`.
  - `MobDrop (i - 1) * 40 + 10` to `(i - 1) * 40 + 19` is the mob drops for group mobs of level `i`.
  - `MobDrop (i - 1) * 40 + 20` to `(i - 1) * 40 + 29` is the mob drops for boss mobs of level `i`.
  - `MobDrop (i - 1) * 40 + 30` to `(i - 1) * 40 + 39` is the mob drops for single mobs of level `i`.
- The rest of the `MobDrop`s are free-form, used for bosses, events and specific Academy outputs.
-  The `MobDrop` IDs are not overwritten by other patches, they are extracted with a mind to "only add mob drops, not remove or edit them" in a patch. This keeps fix patches low-profile.