### PR TITLE
Fusion Father / Fusion Hominid Fix

### DIFF
--- a/patch/1013-fixes/drops.json
+++ b/patch/1013-fixes/drops.json
@@ -1,26 +1,5 @@
 {
     "MobDrops": {
-        "10302": {
-            "MobDropID": 302,
-            "CrateDropChanceID": 1,
-            "CrateDropTypeID": 92,
-            "MiscDropChanceID": 0,
-            "MiscDropTypeID": 31
-        },
-        "10382": {
-            "MobDropID": 382,
-            "CrateDropChanceID": 1,
-            "CrateDropTypeID": 93,
-            "MiscDropChanceID": 0,
-            "MiscDropTypeID": 39
-        },
-        "10473": {
-            "MobDropID": 473,
-            "CrateDropChanceID": 1,
-            "CrateDropTypeID": 106,
-            "MiscDropChanceID": 0,
-            "MiscDropTypeID": 48
-        },
         "10592": {
             "MobDropID": 592,
             "CrateDropChanceID": 0,
@@ -94,9 +73,6 @@
         },
         "10028": {
             "!MobDropID": 562
-        },
-        "10032": {
-            "!MobDropID": 473
         },
         "10033": {
             "!MobDropID": 712

--- a/patch/1013-fixes/drops.json
+++ b/patch/1013-fixes/drops.json
@@ -41,6 +41,13 @@
             "CrateDropTypeID": 104,
             "MiscDropChanceID": 0,
             "MiscDropTypeID": 72
+        },
+        "11476": {
+            "MobDropID": 475,
+            "CrateDropChanceID": 1,
+            "CrateDropTypeID": 106,
+            "MiscDropChanceID": 0,
+            "MiscDropTypeID": 48
         }
     },
     "Mobs": {
@@ -73,6 +80,9 @@
         },
         "10028": {
             "!MobDropID": 562
+        },
+        "10032": {
+            "!MobDropID": 475
         },
         "10033": {
             "!MobDropID": 712


### PR DESCRIPTION
In `1013-fixes` version:
- The Hominid's drops were updated to contain Level 12 Fusion Taro / FM levels at the level of `1013-fixes`. The new MobDrop object was `MobDrop 473`.
- Fusion Father's drops were edited to drop Booster CRATEs in the last update at the level of `1013`. This level has recorded a new `MobDrop 473` (and `MobDrop 474` on top of it), which means the new object overwrote the old one at the `1013-fixes` level.
- As a result, Fusion Father and Fusion Hominid were in an undefined state, as their drops could refer to either `MobDrop 473` object (we should have only have 1 of them). This is the current state pre-PR.

During research:
- Upon re-edit with OFDropEditor, the editor automatically culled the last reference without us issuing any edits. This put us back in the defined behavior area, but Fusion Hominid drops Fusion Father's drops since there's a surviving `"!MobDropID": 473` override for Hominid.

Fix:
- A new `MobDropID 475` is created with Level 12 Fusion Taro / FM levels + `CrateDropChance 1` (100% drop chance for 1 CRATE) + `CrateDropType 106` (Hominid CRATE). The override now points to this new MobDrop.
- Fusion Father's existing config already uses intended `1013`-specified drops as it is, so no specific fixes.
- `MobDrop 302` and `MobDrop 382`, added specifically by the `1013-fixes` patch is not referenced anywhere else, so they were determined as dangling MobDrops and also removed. Since this patch is the latest patch to use in a 1013 + drop fixes scheme (and unused otherwise), this is safe to do.
